### PR TITLE
Remove OverlapType.Long

### DIFF
--- a/src/gtfs/command/ApplyOverlays.ts
+++ b/src/gtfs/command/ApplyOverlays.ts
@@ -40,21 +40,19 @@ function *getDefaultIdGenerator(): IterableIterator<number> {
 }
 
 /**
- * Check if the given schedule overlaps the current one and if necessary divide this schedule into many others.
+ * Check if the given schedule overlaps the current one.
  *
  * If there is no overlap this Schedule will be returned intact.
  */
 function applyOverlay(base: OverlayRecord, overlay: OverlayRecord, ids: IdGenerator): OverlayRecord[] {
   const overlap = base.calendar.getOverlap(overlay.calendar);
 
-  // if this schedules schedule overlaps it at any point
+  // if this schedule overlaps it at any point
   if (overlap === OverlapType.None) {
     return [base];
   }
 
-  return overlap === OverlapType.Short
-    ? base.calendar.addExcludeDays(overlay.calendar).map(calendar => base.clone(calendar, base.id))
-    : base.calendar.divideAround(overlay.calendar).map(calendar => base.clone(calendar, ids.next().value));
+  return base.calendar.addExcludeDays(overlay.calendar).map(calendar => base.clone(calendar, base.id));
 }
 
 

--- a/src/gtfs/native/ScheduleCalendar.ts
+++ b/src/gtfs/native/ScheduleCalendar.ts
@@ -40,18 +40,8 @@ export class ScheduleCalendar {
       return OverlapType.None;
     }
 
-    let numDays = 0;
-
-    for (const sharedDay of this.sharedDays(overlay)) {
-      const key = toYYYYMMDD(sharedDay);
-      const isShared = !this.excludeDays[key] && !overlay.excludeDays[key];
-
-      if (isShared && ++numDays > ScheduleCalendar.SHORT_OVERLAY_LENGTH) {
-        return OverlapType.Long;
-      }
-    }
-
-    return (numDays > 0) ? OverlapType.Short : OverlapType.None;
+    let first = this.sharedDays(overlay).next();
+    return first.done ? OverlapType.None : OverlapType.Overlap;
   }
 
   /**
@@ -314,8 +304,7 @@ export type BankHoliday = string;
 
 export enum OverlapType {
   None = 0,
-  Short = 1,
-  Long = 2
+  Overlap = 1
 }
 
 export const NO_DAYS: Days = { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };

--- a/test/gtfs/command/ApplyOverlays.spec.ts
+++ b/test/gtfs/command/ApplyOverlays.spec.ts
@@ -1,5 +1,4 @@
-import * as chai from "chai";
-import {describe, it, expect} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {STP} from "../../../src/gtfs/native/OverlayRecord";
 import {applyOverlays} from "../../../src/gtfs/command/ApplyOverlays";
 import {mergeSchedules} from "../../../src/gtfs/command/MergeSchedules";
@@ -7,7 +6,7 @@ import {schedule} from "./MergeSchedules.spec";
 
 describe("ApplyOverlays", () => {
 
-  it("adds exclude days for short overlays", () => {
+  it("adds exclude days for overlays", () => {
     const baseSchedules = [
       schedule(1, "A", "2017-01-01", "2017-01-31"),
       schedule(2, "A", "2017-01-05", "2017-01-07", STP.Overlay, { 0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1 })
@@ -58,28 +57,15 @@ describe("ApplyOverlays", () => {
     expect(schedules["A"][1]).to.equal(nolay);
   });
 
-  it("applies a short overlay", () => {
+  it("applies an overlay", () => {
     const perm = schedule(1, "A", "2017-01-01", "2017-01-31");
-    const short = schedule(2, "A", "2017-01-05", "2017-01-07");
+    const overlay = schedule(2, "A", "2017-01-05", "2017-01-07");
 
-    const schedules = applyOverlays([perm, short]);
+    const schedules = applyOverlays([perm, overlay]);
 
     expect(schedules["A"][0]).not.to.equal(perm);
     expect(schedules["A"][0].tuid).to.equal(perm.tuid);
-  });
-
-  it("applies a long overlay", () => {
-    const perm = schedule(1, "A", "2017-01-01", "2017-01-31");
-    const long = schedule(2, "A", "2017-01-02", "2017-01-30");
-
-    const schedules = applyOverlays([perm, long]);
-    const [s1, s2, s3] = schedules["A"];
-
-    expect(s1).not.to.equal(perm);
-    expect(s1.tuid).to.equal(perm.tuid);
-    expect(s2).not.to.equal(perm);
-    expect(s2.tuid).to.equal(perm.tuid);
-    expect(s3).to.equal(long);
+    expect(schedules["A"][1]).to.equal(overlay);
   });
 
   it("removes cancellations", () => {

--- a/test/gtfs/native/ScheduleCalendar.spec.ts
+++ b/test/gtfs/native/ScheduleCalendar.spec.ts
@@ -11,9 +11,9 @@ describe("ScheduleCalendar", () => {
     const overlay = calendar("2017-01-31", "2017-02-07");
     const nolay = calendar("2017-02-05", "2017-02-07");
 
-    expect(perm.getOverlap(underlay)).to.deep.equal(OverlapType.Long);
-    expect(perm.getOverlap(innerlay)).to.deep.equal(OverlapType.Short);
-    expect(perm.getOverlap(overlay)).to.deep.equal(OverlapType.Short);
+    expect(perm.getOverlap(underlay)).to.deep.equal(OverlapType.Overlap);
+    expect(perm.getOverlap(innerlay)).to.deep.equal(OverlapType.Overlap);
+    expect(perm.getOverlap(overlay)).to.deep.equal(OverlapType.Overlap);
     expect(perm.getOverlap(nolay)).to.deep.equal(OverlapType.None);
   });
 
@@ -24,18 +24,18 @@ describe("ScheduleCalendar", () => {
 
     expect(weekday.getOverlap(weekend)).to.deep.equal(OverlapType.None);
     expect(weekend.getOverlap(weekday)).to.deep.equal(OverlapType.None);
-    expect(weekday.getOverlap(tuesday)).to.deep.equal(OverlapType.Short);
+    expect(weekday.getOverlap(tuesday)).to.deep.equal(OverlapType.Overlap);
   });
 
-  it("detects short overlays", () => {
+  it("detects overlays", () => {
     const perm = calendar("2017-01-01", "2017-01-31");
     // Wed + Thurs for two weeks
     const short = calendar("2017-01-11", "2017-01-19", { 0: 0, 1: 0, 2: 0, 3: 1, 4: 1, 5: 0, 6: 0 });
     // full two weeks
     const long = calendar("2017-01-11", "2017-01-19");
 
-    expect(perm.getOverlap(short)).to.deep.equal(OverlapType.Short);
-    expect(perm.getOverlap(long)).to.deep.equal(OverlapType.Long);
+    expect(perm.getOverlap(short)).to.deep.equal(OverlapType.Overlap);
+    expect(perm.getOverlap(long)).to.deep.equal(OverlapType.Overlap);
   });
 
   it("adds exclude days", () => {


### PR DESCRIPTION
This remove OverlapType.Long . The reason for doing this is to provide better customer information that shows accurately when will the service operate, even when long-term engineering works shut the line for 3 weeks.