### PR TITLE
Pr121 update

### DIFF
--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -118,8 +118,8 @@ export class OutputGTFSCommand implements CLICommand {
   }
 
   private getSchedules(associations: Association[], scheduleResults: ScheduleResults): Schedule[] {
-    const processedAssociations = <AssociationIndex>applyOverlays(associations);
-    const processedSchedules = <ScheduleIndex>applyOverlays(scheduleResults.schedules, scheduleResults.idGenerator);
+    const processedAssociations: AssociationIndex = applyOverlays(associations);
+    const processedSchedules: ScheduleIndex = applyOverlays(scheduleResults.schedules);
     const associatedSchedules = applyAssociations(processedSchedules, processedAssociations, scheduleResults.idGenerator);
     const mergedSchedules = <Schedule[]>mergeSchedules(associatedSchedules);
     const schedules = addLateNightServices(mergedSchedules, scheduleResults.idGenerator);

--- a/src/gtfs/command/ApplyOverlays.ts
+++ b/src/gtfs/command/ApplyOverlays.ts
@@ -1,12 +1,11 @@
-
 import {IdGenerator, OverlayRecord, STP} from "../native/OverlayRecord";
 import {OverlapType} from "../native/ScheduleCalendar";
 
 /**
  * Index the schedules by TUID, detect overlays and create new schedules as necessary.
  */
-export function applyOverlays(schedules: OverlayRecord[], idGenerator: IdGenerator = getDefaultIdGenerator()): OverlayIndex {
-  const schedulesByTuid: OverlayIndex = {};
+export function applyOverlays<T extends OverlayRecord>(schedules: T[], idGenerator: IdGenerator = getDefaultIdGenerator()): OverlayIndex<T> {
+  const schedulesByTuid: OverlayIndex<T> = {};
 
   for (const schedule of schedules) {
     // for all cancellation or overlays (perms don't overlap)
@@ -14,8 +13,9 @@ export function applyOverlays(schedules: OverlayRecord[], idGenerator: IdGenerat
       // get any schedules that share the same TUID
       for (const baseSchedule of schedulesByTuid[schedule.tuid] || []) {
         // remove the underlying schedule and add the replacement(s)
+        const overlay = applyOverlay(baseSchedule, schedule, idGenerator);
         schedulesByTuid[schedule.tuid].splice(
-          schedulesByTuid[schedule.tuid].indexOf(baseSchedule), 1, ...applyOverlay(baseSchedule, schedule, idGenerator)
+          schedulesByTuid[schedule.tuid].indexOf(baseSchedule), 1, ...overlay === null ? [] : [overlay]
         );
       }
     }
@@ -40,24 +40,24 @@ function *getDefaultIdGenerator(): IterableIterator<number> {
 }
 
 /**
- * Check if the given schedule overlaps the current one and if necessary divide this schedule into many others.
+ * Check if the given schedule overlaps the current one and if necessary add exclude days to this schedule.
  *
  * If there is no overlap this Schedule will be returned intact.
  */
-function applyOverlay(base: OverlayRecord, overlay: OverlayRecord, ids: IdGenerator): OverlayRecord[] {
+function applyOverlay<T extends OverlayRecord>(base: T, overlay: T, ids: IdGenerator): T | null {
   const overlap = base.calendar.getOverlap(overlay.calendar);
 
   // if this schedules schedule overlaps it at any point
   if (overlap === OverlapType.None) {
-    return [base];
+    return base;
   }
 
-  return overlap === OverlapType.Short
-    ? base.calendar.addExcludeDays(overlay.calendar).map(calendar => base.clone(calendar, base.id))
-    : base.calendar.divideAround(overlay.calendar).map(calendar => base.clone(calendar, ids.next().value));
+  const newCalendar = base.calendar.addExcludeDays(overlay.calendar);
+
+  return newCalendar === null ? null : base.clone(newCalendar, base.id);
 }
 
 
-export type OverlayIndex = {
-  [tuid: string]: OverlayRecord[]
+export type OverlayIndex<T extends OverlayRecord> = {
+  [tuid: string]: T[]
 }

--- a/src/gtfs/command/ApplyOverlays.ts
+++ b/src/gtfs/command/ApplyOverlays.ts
@@ -1,23 +1,21 @@
-import {IdGenerator, OverlayRecord, STP} from "../native/OverlayRecord";
+import {OverlayRecord, STP} from "../native/OverlayRecord";
 import {OverlapType} from "../native/ScheduleCalendar";
 
 /**
  * Index the schedules by TUID, detect overlays and create new schedules as necessary.
  */
-export function applyOverlays<T extends OverlayRecord>(schedules: T[], idGenerator: IdGenerator = getDefaultIdGenerator()): OverlayIndex<T> {
+export function applyOverlays<T extends OverlayRecord>(schedules: T[]): OverlayIndex<T> {
   const schedulesByTuid: OverlayIndex<T> = {};
 
   for (const schedule of schedules) {
-    // for all cancellation or overlays (perms don't overlap)
-    if (schedule.stp !== STP.Permanent) {
-      // get any schedules that share the same TUID
-      for (const baseSchedule of schedulesByTuid[schedule.tuid] || []) {
-        // remove the underlying schedule and add the replacement(s)
-        const overlay = applyOverlay(baseSchedule, schedule, idGenerator);
-        schedulesByTuid[schedule.tuid].splice(
-          schedulesByTuid[schedule.tuid].indexOf(baseSchedule), 1, ...overlay === null ? [] : [overlay]
-        );
-      }
+    // permanent records are applied as overlays too - z_schedule is entirely permanent and its
+    // records do overlap each other
+    for (const baseSchedule of schedulesByTuid[schedule.tuid] || []) {
+      // remove the underlying schedule and add the replacement
+      const overlay = applyOverlay(baseSchedule, schedule);
+      schedulesByTuid[schedule.tuid].splice(
+        schedulesByTuid[schedule.tuid].indexOf(baseSchedule), 1, ...overlay === null ? [] : [overlay]
+      );
     }
 
     // add the schedule to the index, unless it's a cancellation
@@ -30,21 +28,11 @@ export function applyOverlays<T extends OverlayRecord>(schedules: T[], idGenerat
 }
 
 /**
- * Return a Iterator that generates incremental numbers starting at the given number
- */
-function *getDefaultIdGenerator(): IterableIterator<number> {
-  let id = 0;
-  while (true) {
-    yield id++;
-  }
-}
-
-/**
  * Check if the given schedule overlaps the current one and if necessary add exclude days to this schedule.
  *
  * If there is no overlap this Schedule will be returned intact.
  */
-function applyOverlay<T extends OverlayRecord>(base: T, overlay: T, ids: IdGenerator): T | null {
+function applyOverlay<T extends OverlayRecord>(base: T, overlay: T): T | null {
   const overlap = base.calendar.getOverlap(overlay.calendar);
 
   // if this schedules schedule overlaps it at any point
@@ -54,7 +42,7 @@ function applyOverlay<T extends OverlayRecord>(base: T, overlay: T, ids: IdGener
 
   const newCalendar = base.calendar.addExcludeDays(overlay.calendar);
 
-  return newCalendar === null ? null : base.clone(newCalendar, base.id);
+  return newCalendar === null ? null : base.clone(newCalendar, base.id) as T;
 }
 
 

--- a/src/gtfs/command/Frequency.ts
+++ b/src/gtfs/command/Frequency.ts
@@ -1,6 +1,6 @@
 
 export interface Frequency {
-  trip_id: number;
+  trip_id: string;
   start_time: string;
   end_time: string;
   headway_secs: number;

--- a/src/gtfs/command/MergeSchedules.ts
+++ b/src/gtfs/command/MergeSchedules.ts
@@ -5,22 +5,42 @@ import {Schedule} from "../native/Schedule";
  * Flatten the index into a list of schedules, ensuring that there are no duplicate trip IDs
  */
 export function mergeSchedules(schedulesByTuid: ScheduleIndex): Schedule[] {
-  const schedulesByTripId: { [tripId: string]: Schedule } = {};
+  const schedulesByTripId = new Map<string, Schedule>();
 
-  for (const tuid in schedulesByTuid) {
-    if (schedulesByTuid.hasOwnProperty(tuid)) {
-      for (const schedule of schedulesByTuid[tuid]) {
-        const tripId = schedule.tripId;
-        if (schedulesByTripId[tripId] !== undefined) {
-          throw new Error(`Duplicate trip_id ${tripId} detected. This should not happen. Please file a bug report.`);
-        }
-        if (schedule.stopTimes.length && schedule.stopTimes[0].trip_id !== tripId) {
-          throw new Error(`The trip_id of the stop times do not match the trip_id for trip ${tripId}. This should not happen. Please file a bug report.`);
-        }
-        schedulesByTripId[tripId] = schedule;
+  for (const schedules of Object.values(schedulesByTuid)) {
+    for (const schedule of schedules) {
+      let tripId = schedule.tripId;
+
+      // the same two trains may be associated more than once over the same dates
+      for (let occurrence = 2; schedulesByTripId.has(tripId); occurrence++) {
+        tripId = `${schedule.tripId}_${occurrence}`;
       }
+
+      schedulesByTripId.set(tripId, withTripId(schedule, tripId));
     }
   }
 
-  return Object.values(schedulesByTripId);
+  return [...schedulesByTripId.values()];
+}
+
+/**
+ * Point the schedule's stop times at the given trip ID so that stop_times.txt joins to trips.txt
+ */
+function withTripId(schedule: Schedule, tripId: string): Schedule {
+  if (schedule.stopTimes.length === 0 || schedule.stopTimes[0].trip_id === tripId) {
+    return schedule;
+  }
+
+  return new Schedule(
+    schedule.id,
+    schedule.stopTimes.map(st => Object.assign({}, st, { trip_id: tripId })),
+    schedule.tuid,
+    schedule.rsid,
+    schedule.calendar,
+    schedule.mode,
+    schedule.operator,
+    schedule.stp,
+    schedule.firstClassAvailable,
+    schedule.reservationPossible
+  );
 }

--- a/src/gtfs/command/MergeSchedules.ts
+++ b/src/gtfs/command/MergeSchedules.ts
@@ -1,43 +1,26 @@
-import {OverlayRecord} from "../native/OverlayRecord";
-import {OverlayIndex} from "./ApplyOverlays";
-import {compare} from "../native/PlainDate";
+import {ScheduleIndex} from "./ApplyAssociations";
+import {Schedule} from "../native/Schedule";
 
 /**
- * Flatten the index into a list of schedules, detecting any schedules that can be merged in the process.
+ * Flatten the index into a list of schedules, ensuring that there are no duplicate trip IDs
  */
-export function mergeSchedules(schedulesByTuid: OverlayIndex): OverlayRecord[] {
-  const results: OverlayRecord[] = [];
+export function mergeSchedules(schedulesByTuid: ScheduleIndex): Schedule[] {
+  const schedulesByTripId: { [tripId: string]: Schedule } = {};
 
   for (const tuid in schedulesByTuid) {
-    // group schedules that run on the same days with the exact same stopping pattern
-    const schedulesByHash = schedulesByTuid[tuid].reduce((prev: OverlayIndex, cur) => {
-      (prev[cur.hash] = prev[cur.hash] || []).push(cur);
-
-      return prev;
-    }, {});
-
-    // for each group of schedules that might be merged
-    for (const groupedSchedules of Object.values(schedulesByHash)) {
-      // sortSchedules by start date
-      groupedSchedules.sort(sortOverlays);
-
-      // iterate through each schedule
-      for (let i = 0; i < groupedSchedules.length; i++) {
-        let scheduleI = groupedSchedules[i];
-
-        // merge as many schedules in as possible
-        while (groupedSchedules[i + 1] && scheduleI.calendar.canMerge(groupedSchedules[i + 1].calendar)) {
-          scheduleI = scheduleI.clone(scheduleI.calendar.merge(groupedSchedules[++i].calendar), scheduleI.id);
+    if (schedulesByTuid.hasOwnProperty(tuid)) {
+      for (const schedule of schedulesByTuid[tuid]) {
+        const tripId = schedule.tripId;
+        if (schedulesByTripId[tripId] !== undefined) {
+          throw new Error(`Duplicate trip_id ${tripId} detected. This should not happen. Please file a bug report.`);
         }
-
-        results.push(scheduleI);
+        if (schedule.stopTimes.length && schedule.stopTimes[0].trip_id !== tripId) {
+          throw new Error(`The trip_id of the stop times do not match the trip_id for trip ${tripId}. This should not happen. Please file a bug report.`);
+        }
+        schedulesByTripId[tripId] = schedule;
       }
     }
   }
 
-  return results;
-}
-
-function sortOverlays(a: OverlayRecord, b: OverlayRecord): number {
-  return compare(a.calendar.runsFrom, b.calendar.runsFrom) <= 0 ? -1 : 1;
+  return Object.values(schedulesByTripId);
 }

--- a/src/gtfs/file/StopTime.ts
+++ b/src/gtfs/file/StopTime.ts
@@ -2,7 +2,7 @@
 import {CRS} from "./Stop";
 
 export interface StopTime {
-  trip_id: number;
+  trip_id: string;
   arrival_time: string;
   departure_time: string;
   stop_id: CRS;

--- a/src/gtfs/file/Trip.ts
+++ b/src/gtfs/file/Trip.ts
@@ -3,7 +3,7 @@ import {RSID, TUID} from "../native/OverlayRecord";
 export interface Trip {
   route_id: number;
   service_id: number;
-  trip_id: number;
+  trip_id: string;
   trip_headsign: TUID;
   trip_short_name: RSID;
   direction_id: 0 | 1;

--- a/src/gtfs/native/Association.ts
+++ b/src/gtfs/native/Association.ts
@@ -5,7 +5,7 @@ import {CRS, Stop} from "../file/Stop";
 import {IdGenerator, OverlayRecord, STP, TUID} from "./OverlayRecord";
 import {StopTime} from "../file/StopTime";
 import {Duration, formatDuration, parseDuration, SECONDS_IN_DAY} from "./Duration";
-import {compare, maxDate, minDate} from "./PlainDate";
+import {compare, maxDate, minDate, toYYYYMMDD} from "./PlainDate";
 
 export class Association implements OverlayRecord {
 
@@ -49,34 +49,19 @@ export class Association implements OverlayRecord {
    * association does not and create additional schedules to cover those periods.
    */
   public apply(base: Schedule, assoc: Schedule, idGenerator: IdGenerator): Schedule[] {
-    const assocCalendar = this.dateIndicator === DateIndicator.Next ? this.calendar.shiftForward() : this.calendar;
-    const schedules = [this.mergeSchedules(base, assoc)];
-
-    // if the associated train starts running before the association, clone the associated schedule for those dates
-    if (compare(assoc.calendar.runsFrom, assocCalendar.runsFrom) < 0) {
-      const before = assoc.calendar.clone(assoc.calendar.runsFrom, assocCalendar.runsFrom.subtract({ days: 1 }));
-
-      if (!before.isEmpty) {
-        schedules.push(assoc.clone(before, idGenerator.next().value));
-      }
+    const assocCalendar = this.dateIndicator === DateIndicator.Next ? this.calendar.shiftForward() :
+        this.dateIndicator === DateIndicator.Previous ? this.calendar.shiftBackward() : this.calendar;
+    const mergedBase = this.mergeSchedules(base, assoc);
+    if (mergedBase === null) {
+      // the association does not apply
+      return [assoc];
     }
+    const schedules = [mergedBase];
 
-    // if the associated train runs after the association has finished, clone the associated schedule for those dates
-    if (compare(assoc.calendar.runsTo, assocCalendar.runsTo) > 0) {
-      const after = assoc.calendar.clone(assocCalendar.runsTo.add({ days: 1 }), assoc.calendar.runsTo);
-
-      if (!after.isEmpty) {
-        schedules.push(assoc.clone(after, idGenerator.next().value));
-      }
-    }
-
-    // for each exclude day of the association
-    for (const excludeDay of Object.values(assocCalendar.excludeDays)) {
-      const excluded = assoc.calendar.clone(excludeDay, excludeDay);
-
-      if (!excluded.isEmpty) {
-        schedules.push(assoc.clone(excluded, idGenerator.next().value));
-      }
+    // exclude the associated schedule from running when the association is active
+    const excludeCalendar = assoc.calendar.addExcludeDays(assocCalendar);
+    if (excludeCalendar !== null) {
+      schedules.push(assoc.clone(excludeCalendar, idGenerator.next().value));
     }
 
     return schedules;
@@ -85,7 +70,7 @@ export class Association implements OverlayRecord {
   /**
    * Apply the split or join to the given schedules
    */
-  private mergeSchedules(base: Schedule, assoc: Schedule): Schedule {
+  private mergeSchedules(base: Schedule, assoc: Schedule): Schedule | null {
     let tuid: TUID;
     let start: StopTime[];
     let assocStop: StopTime;
@@ -96,7 +81,7 @@ export class Association implements OverlayRecord {
 
     // this should never happen, unless data feed is corrupted. It will prevent us from update failure
     if (baseStopTime === undefined || assocStopTime === undefined) {
-      return assoc;
+      return null;
     }
 
     if (this.assocType === AssociationType.Split) {
@@ -115,14 +100,24 @@ export class Association implements OverlayRecord {
     }
 
     let stopSequence: number = 1;
+    const calendar = this.dateIndicator === DateIndicator.Next ? assoc.calendar.shiftBackward() : assoc.calendar;
+    const thisCalendar = this.dateIndicator === DateIndicator.Previous ? this.calendar.shiftBackward() : this.calendar;
+
+    const newCalendar = calendar.clone(
+        maxDate(thisCalendar.runsFrom, calendar.runsFrom),
+        minDate(thisCalendar.runsTo, calendar.runsTo),
+        NO_DAYS,
+        {...calendar.excludeDays, ...thisCalendar.excludeDays}
+    );
+    if (newCalendar === null) return null;
+    const tripId = `${tuid}_${toYYYYMMDD(newCalendar.runsFrom)}_${toYYYYMMDD(newCalendar.runsTo)}`;
 
     const stops = [
-      ...start.map(s => this.cloneStop(s, stopSequence++, assoc.id)),
-      this.cloneStop(assocStop, stopSequence++, assoc.id),
-      ...end.map(s => this.cloneStop(s, stopSequence++, assoc.id, assocStop))
+      ...start.map(s => this.cloneStop(s, stopSequence++, tripId, false)),
+      this.cloneStop(assocStop, stopSequence++, tripId, false),
+      ...end.map(s => this.cloneStop(s, stopSequence++, tripId, this.assocType === AssociationType.Split && this.dateIndicator === DateIndicator.Next || this.assocType === AssociationType.Join && this.dateIndicator === DateIndicator.Previous))
     ];
 
-    const calendar = this.dateIndicator === DateIndicator.Next ? assoc.calendar.shiftBackward() : assoc.calendar;
 
     return new Schedule(
       assoc.id,
@@ -169,33 +164,23 @@ export class Association implements OverlayRecord {
   /**
    * Clone the given stop overriding the sequence number and modifying the arrival/departure times if necessary
    */
-  private cloneStop(stop: StopTime, stopSequence: number, tripId: number, assocStop: StopTime | null = null): StopTime {
-    const assocTime = parseDuration(assocStop && assocStop.arrival_time ? assocStop.arrival_time : "00:00");
+  private cloneStop(stop: StopTime, stopSequence: number, tripId: string, nextDay: boolean): StopTime {
+    let departureTime = stop.departure_time ? parseDuration(stop.departure_time) : null;
+    let arrivalTime = stop.arrival_time ? parseDuration(stop.arrival_time) : null;
+    if (nextDay) {
+      if (departureTime !== null) departureTime += SECONDS_IN_DAY;
+      if (arrivalTime !== null) arrivalTime += SECONDS_IN_DAY;
+    }
+
 
     return Object.assign({}, stop, {
-      arrival_time: this.shiftPastAssociation(stop.arrival_time, assocTime),
-      departure_time: this.shiftPastAssociation(stop.departure_time, assocTime),
+      arrival_time: arrivalTime ? formatDuration(arrivalTime) : null,
+      departure_time: departureTime ? formatDuration(departureTime) : null,
       stop_sequence: stopSequence,
       trip_id: tripId
     });
   }
-
-  /**
-   * Format the given stop time, pushing it into the next day if it falls before the association.
-   *
-   * The absent check is on the string rather than the parsed seconds because midnight is a real time
-   * but zero seconds is falsy.
-   */
-  private shiftPastAssociation(time: string | undefined, assocTime: Duration): string | undefined {
-    if (!time) {
-      return undefined;
-    }
-
-    const seconds = parseDuration(time);
-
-    return formatDuration(seconds < assocTime ? seconds + SECONDS_IN_DAY : seconds);
-  }
-
+  
 }
 
 export enum DateIndicator {

--- a/src/gtfs/native/Association.ts
+++ b/src/gtfs/native/Association.ts
@@ -1,11 +1,11 @@
 
-import {Schedule} from "./Schedule";
+import {Schedule, tripId as tripIdFor} from "./Schedule";
 import {NO_DAYS, OverlapType, ScheduleCalendar} from "./ScheduleCalendar";
 import {CRS, Stop} from "../file/Stop";
 import {IdGenerator, OverlayRecord, STP, TUID} from "./OverlayRecord";
 import {StopTime} from "../file/StopTime";
-import {Duration, formatDuration, parseDuration, SECONDS_IN_DAY} from "./Duration";
-import {compare, maxDate, minDate, toYYYYMMDD} from "./PlainDate";
+import {formatDuration, parseDuration, SECONDS_IN_DAY} from "./Duration";
+import {maxDate, minDate} from "./PlainDate";
 
 export class Association implements OverlayRecord {
 
@@ -21,11 +21,7 @@ export class Association implements OverlayRecord {
   ) { }
 
   public get tuid(): TUID {
-    return this.baseTUID + "_" + this.assocTUID + "_";
-  }
-
-  public get hash(): string {
-    return this.tuid + this.assocLocation + this.calendar.binaryDays;
+    return this.baseTUID + "_" + this.assocTUID + "_" + this.assocLocation;
   }
 
   /**
@@ -109,8 +105,11 @@ export class Association implements OverlayRecord {
         NO_DAYS,
         {...calendar.excludeDays, ...thisCalendar.excludeDays}
     );
-    if (newCalendar === null) return null;
-    const tripId = `${tuid}_${toYYYYMMDD(newCalendar.runsFrom)}_${toYYYYMMDD(newCalendar.runsTo)}`;
+    if (newCalendar.isEmpty) {
+      return null;
+    }
+
+    const tripId = tripIdFor(tuid, newCalendar);
 
     const stops = [
       ...start.map(s => this.cloneStop(s, stopSequence++, tripId, false)),
@@ -125,10 +124,7 @@ export class Association implements OverlayRecord {
       tuid,
       assoc.rsid,
       // only take the part of the schedule that the association applies to
-      calendar.clone(
-        maxDate(this.calendar.runsFrom, calendar.runsFrom),
-        minDate(this.calendar.runsTo, calendar.runsTo)
-      ),
+      newCalendar,
       assoc.mode,
       assoc.operator,
       assoc.stp,

--- a/src/gtfs/native/OverlayRecord.ts
+++ b/src/gtfs/native/OverlayRecord.ts
@@ -7,7 +7,7 @@ export interface OverlayRecord {
   tuid: TUID;
   hash: string;
 
-  clone(calendar: ScheduleCalendar, scheduleId: number): OverlayRecord;
+  clone(calendar: ScheduleCalendar, scheduleId: number): this;
 }
 
 

--- a/src/gtfs/native/OverlayRecord.ts
+++ b/src/gtfs/native/OverlayRecord.ts
@@ -5,9 +5,8 @@ export interface OverlayRecord {
   stp: STP;
   id: number;
   tuid: TUID;
-  hash: string;
 
-  clone(calendar: ScheduleCalendar, scheduleId: number): this;
+  clone(calendar: ScheduleCalendar, scheduleId: number): OverlayRecord;
 }
 
 
@@ -15,9 +14,9 @@ export type TUID = string;
 export type RSID = string;
 
 export enum STP {
-  Permanent = "Previous",
+  Permanent = "P",
   Overlay = "O",
-  New = "Next",
+  New = "N",
   Cancellation = "C"
 }
 

--- a/src/gtfs/native/Schedule.ts
+++ b/src/gtfs/native/Schedule.ts
@@ -1,12 +1,11 @@
-
 import {StopTime} from "../file/StopTime";
-import {OverlapType, ScheduleCalendar} from "./ScheduleCalendar";
+import {ScheduleCalendar} from "./ScheduleCalendar";
 import {Trip} from "../file/Trip";
 import {Route, RouteType} from "../file/Route";
 import {AgencyID} from "../file/Agency";
 import {CRS} from "../file/Stop";
-import {IdGenerator, OverlayRecord, RSID, STP, TUID} from "./OverlayRecord";
-import memoize from "memoized-class-decorator";
+import {OverlayRecord, RSID, STP, TUID} from "./OverlayRecord";
+import {toYYYYMMDD} from "./PlainDate";
 
 /**
  * A CIF schedule (BS record)
@@ -25,6 +24,10 @@ export class Schedule implements OverlayRecord {
     public readonly firstClassAvailable: boolean,
     public readonly reservationPossible: boolean
   ) {}
+  
+  public get tripId(): string {
+    return `${this.tuid}_${toYYYYMMDD(this.calendar.runsFrom)}_${toYYYYMMDD(this.calendar.runsTo)}`
+  }
 
   public get origin(): CRS {
     return this.stopTimes[0].stop_id;
@@ -41,10 +44,10 @@ export class Schedule implements OverlayRecord {
   /**
    * Clone the current record with the new calendar and id
    */
-  public clone(calendar: ScheduleCalendar, scheduleId: number): Schedule {
+  public clone(calendar: ScheduleCalendar, scheduleId: number): this {
     return new Schedule(
       scheduleId,
-      this.stopTimes.map(st => Object.assign({}, st, { trip_id: scheduleId })),
+      this.stopTimes,
       this.tuid,
       this.rsid,
       calendar,
@@ -53,7 +56,7 @@ export class Schedule implements OverlayRecord {
       this.stp,
       this.firstClassAvailable,
       this.reservationPossible
-    );
+    ) as this;
   }
 
   /**
@@ -63,7 +66,7 @@ export class Schedule implements OverlayRecord {
     return {
       route_id: routeId,
       service_id: serviceId,
-      trip_id: this.id,
+      trip_id: this.stopTimes[0].trip_id,
       trip_headsign: this.tuid,
       trip_short_name: this.rsid,
       direction_id: 0,

--- a/src/gtfs/native/Schedule.ts
+++ b/src/gtfs/native/Schedule.ts
@@ -8,6 +8,17 @@ import {OverlayRecord, RSID, STP, TUID} from "./OverlayRecord";
 import {toYYYYMMDD} from "./PlainDate";
 
 /**
+ * The identifier for a trip, stable across data revisions.
+ *
+ * The STP indicator is deliberately left out, so that when an overlay covering a whole permanent
+ * schedule is withdrawn the trip keeps its ID and reads as an amended timetable rather than one
+ * trip disappearing and another appearing.
+ */
+export function tripId(tuid: TUID, calendar: ScheduleCalendar): string {
+  return `${tuid}_${toYYYYMMDD(calendar.runsFrom)}_${toYYYYMMDD(calendar.runsTo)}`;
+}
+
+/**
  * A CIF schedule (BS record)
  */
 export class Schedule implements OverlayRecord {
@@ -26,7 +37,7 @@ export class Schedule implements OverlayRecord {
   ) {}
   
   public get tripId(): string {
-    return `${this.tuid}_${toYYYYMMDD(this.calendar.runsFrom)}_${toYYYYMMDD(this.calendar.runsTo)}`
+    return tripId(this.tuid, this.calendar);
   }
 
   public get origin(): CRS {
@@ -37,17 +48,15 @@ export class Schedule implements OverlayRecord {
     return this.stopTimes[this.stopTimes.length - 1].stop_id;
   }
 
-  public get hash(): string {
-    return this.tuid + this.stopTimes.map(s => s.stop_id + s.departure_time + s.arrival_time).join("") + this.calendar.binaryDays;
-  }
-
   /**
-   * Clone the current record with the new calendar and id
+   * Clone the current record with the new calendar and id.
+   *
+   * The stop times are copied because callers shift the times of a clone in place.
    */
-  public clone(calendar: ScheduleCalendar, scheduleId: number): this {
+  public clone(calendar: ScheduleCalendar, scheduleId: number): Schedule {
     return new Schedule(
       scheduleId,
-      this.stopTimes,
+      this.stopTimes.map(st => Object.assign({}, st)),
       this.tuid,
       this.rsid,
       calendar,
@@ -56,7 +65,7 @@ export class Schedule implements OverlayRecord {
       this.stp,
       this.firstClassAvailable,
       this.reservationPossible
-    ) as this;
+    );
   }
 
   /**

--- a/src/gtfs/native/ScheduleCalendar.ts
+++ b/src/gtfs/native/ScheduleCalendar.ts
@@ -25,10 +25,18 @@ export class ScheduleCalendar {
   }
 
   /**
-   * Returns true if the calendar does not run on any days e.g. the date range has been tightened beyond its bounds
+   * Returns true if the calendar does not run on any days e.g. when the whole day range has been excluded
    */
   public get isEmpty(): boolean {
-    return compare(this.runsFrom, this.runsTo) > 0;
+    const start = this.runsFrom;
+    const end = this.runsTo;
+
+    for (let date = start; compare(date, end) <= 0; date = date.add({ days: 1 })) {
+      if (this.days[dayOfWeek(date)] && !this.excludeDays[toYYYYMMDD(date)]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -40,24 +48,14 @@ export class ScheduleCalendar {
       return OverlapType.None;
     }
 
-    let numDays = 0;
-
-    for (const sharedDay of this.sharedDays(overlay)) {
-      const key = toYYYYMMDD(sharedDay);
-      const isShared = !this.excludeDays[key] && !overlay.excludeDays[key];
-
-      if (isShared && ++numDays > ScheduleCalendar.SHORT_OVERLAY_LENGTH) {
-        return OverlapType.Long;
-      }
-    }
-
-    return (numDays > 0) ? OverlapType.Short : OverlapType.None;
+    let first = this.sharedDays(overlay).next();
+    return first.done ? OverlapType.None : OverlapType.Overlap;
   }
 
   /**
    * Add each date in the range as an exclude day
    */
-  public addExcludeDays(overlay: ScheduleCalendar): ScheduleCalendar[] {
+  public addExcludeDays(overlay: ScheduleCalendar): ScheduleCalendar | null {
     const excludeDays = Object.assign({}, this.excludeDays); // clone
 
     for (const sharedDay of this.sharedDays(overlay)) {
@@ -66,11 +64,11 @@ export class ScheduleCalendar {
 
     const calendar = this.clone(this.runsFrom, this.runsTo, NO_DAYS, excludeDays);
 
-    return calendar.isEmpty ? [] : [calendar];
+    return calendar.isEmpty ? null : calendar;
   }
 
   /**
-   * Returns the overlapping days between schedules (does not account for exclude days)
+   * Returns the overlapping days between schedules, accounting for exclude days for each calendar
    */
   private* sharedDays(overlay: ScheduleCalendar) {
     const endDate = minDate(this.runsTo, overlay.runsTo);
@@ -79,7 +77,8 @@ export class ScheduleCalendar {
     while (compare(date, endDate) <= 0) {
       const day = dayOfWeek(date);
 
-      if (this.days[day] && overlay.days[day]) {
+      if (this.days[day] && overlay.days[day]
+        && !this.excludeDays[toYYYYMMDD(date)] && !overlay.excludeDays[toYYYYMMDD(date)]) {
         yield date;
       }
 
@@ -88,29 +87,7 @@ export class ScheduleCalendar {
   }
 
   /**
-   * Remove the given date range from this schedule and return one or two calendars
-   */
-  public divideAround(calendar: ScheduleCalendar): ScheduleCalendar[] {
-    const calendars: ScheduleCalendar[] = [
-      this.clone(this.runsFrom, calendar.runsFrom.subtract({ days: 1 })),
-      this.clone(calendar.runsTo.add({ days: 1 }), this.runsTo)
-    ];
-
-    // if there are any days left after applying the overlay
-    if (this.binaryDays - (this.binaryDays & calendar.binaryDays) > 0) {
-      calendars.push(this.clone(
-        calendar.runsFrom,
-        calendar.runsTo,
-        calendar.days,
-        this.excludeDays
-      ));
-    }
-
-    return calendars.filter(c => !c.isEmpty);
-  }
-
-  /**
-   * Remove the given days from the calendar then tighten the dates
+   * Remove the given days from the calendar
    */
   public clone(start: Temporal.PlainDate,
                end: Temporal.PlainDate,
@@ -120,16 +97,6 @@ export class ScheduleCalendar {
     const days = this.removeDays(removeDays);
     let startDate = start;
     let endDate = end;
-
-    // skip forward to the first day the schedule is operating
-    while ((days[dayOfWeek(startDate)] === 0 || excludeDays[toYYYYMMDD(startDate)]) && compare(startDate, endDate) <= 0) {
-      startDate = startDate.add({ days: 1 });
-    }
-
-    // skip backward to the first day the schedule is operating
-    while ((days[dayOfWeek(endDate)] === 0 || excludeDays[toYYYYMMDD(endDate)]) && compare(endDate, startDate) >= 0) {
-      endDate = endDate.subtract({ days: 1 });
-    }
 
     const newExcludes = Object
       .values(excludeDays)
@@ -180,59 +147,6 @@ export class ScheduleCalendar {
         exception_type: 2
       };
     });
-  }
-
-  /**
-   * Returns true if this calendar would not be valid on any days before the given calendar starts
-   */
-  public canMerge(calendar: ScheduleCalendar): boolean {
-    let date = this.runsTo.add({ days: 1 });
-    let numAdditionalExcludeDays = 0;
-
-    while (compare(date, calendar.runsFrom) < 0) {
-      if (this.days[dayOfWeek(date)] && ++numAdditionalExcludeDays > ScheduleCalendar.SHORT_OVERLAY_LENGTH) {
-        return false;
-      }
-
-      date = date.add({ days: 1 });
-    }
-
-    return true;
-  }
-
-  /**
-   * Return a new calendar starting from the runsFrom of this calendar and running to the runsTo of the given calendar.
-   *
-   * Exclude days are merged together.
-   */
-  public merge(calendar: ScheduleCalendar): ScheduleCalendar {
-    const excludeDays = Object.assign({}, calendar.excludeDays, this.excludeDays);
-    let date = this.runsTo.add({ days: 1 });
-
-    while (compare(date, calendar.runsFrom) < 0) {
-      if (this.days[dayOfWeek(date)]) {
-        excludeDays[toYYYYMMDD(date)] = date;
-      }
-
-      date = date.add({ days: 1 });
-    }
-
-    // for any shared
-    for (const sharedDay of this.sharedDays(calendar)) {
-      const key = toYYYYMMDD(sharedDay);
-
-      // if the shared day is only excluded in one overlay, remove it
-      if (!(this.excludeDays[key] && calendar.excludeDays[key])) {
-        delete excludeDays[key];
-      }
-    }
-
-    return new ScheduleCalendar(
-      this.runsFrom,
-      maxDate(this.runsTo, calendar.runsTo),
-      this.days,
-      excludeDays
-    );
   }
 
   /**
@@ -314,8 +228,7 @@ export type BankHoliday = string;
 
 export enum OverlapType {
   None = 0,
-  Short = 1,
-  Long = 2
+  Overlap = 1
 }
 
 export const NO_DAYS: Days = { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };

--- a/src/gtfs/native/ScheduleCalendar.ts
+++ b/src/gtfs/native/ScheduleCalendar.ts
@@ -5,8 +5,6 @@ import {CalendarDate} from "../file/CalendarDate";
 import {compare, dayOfWeek, maxDate, minDate, toYYYYMMDD} from "./PlainDate";
 
 export class ScheduleCalendar {
-  public static readonly SHORT_OVERLAY_LENGTH = 7;
-
   constructor(
     public readonly runsFrom: Temporal.PlainDate,
     public readonly runsTo: Temporal.PlainDate,

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -1,11 +1,10 @@
 import {IdGenerator, STP} from "../native/OverlayRecord";
-import {Schedule} from "../native/Schedule";
+import {Schedule, tripId} from "../native/Schedule";
 import {RouteType} from "../file/Route";
-import {ScheduleCalendar} from "../native/ScheduleCalendar";
+import {NO_DAYS, ScheduleCalendar} from "../native/ScheduleCalendar";
 import {ScheduleStopTimeRow} from "./CIFRepository";
 import {StopTime} from "../file/StopTime";
 import {agencies} from "../../../config/gtfs/agency";
-import {toYYYYMMDD} from "../native/PlainDate";
 
 const pickupActivities = ["T ", "TB", "U "];
 const dropOffActivities = ["T ", "TF", "D "];
@@ -20,7 +19,11 @@ export class ScheduleBuilder {
   private maxId: number = 0;
 
   private getTripId(row: ScheduleStopTimeRow) {
-    return `${row.train_uid}_${toYYYYMMDD(Temporal.PlainDate.from(row.runs_from))}_${toYYYYMMDD(Temporal.PlainDate.from(row.runs_to))}`;
+    return tripId(row.train_uid, new ScheduleCalendar(
+      Temporal.PlainDate.from(row.runs_from),
+      Temporal.PlainDate.from(row.runs_to),
+      NO_DAYS
+    ));
   }
 
   /**

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -4,7 +4,8 @@ import {RouteType} from "../file/Route";
 import {ScheduleCalendar} from "../native/ScheduleCalendar";
 import {ScheduleStopTimeRow} from "./CIFRepository";
 import {StopTime} from "../file/StopTime";
-import { agencies } from "../../../config/gtfs/agency";
+import {agencies} from "../../../config/gtfs/agency";
+import {toYYYYMMDD} from "../native/PlainDate";
 
 const pickupActivities = ["T ", "TB", "U "];
 const dropOffActivities = ["T ", "TF", "D "];
@@ -17,6 +18,10 @@ const notAdvertised = "N ";
 export class ScheduleBuilder {
   private readonly schedules: Schedule[] = [];
   private maxId: number = 0;
+
+  private getTripId(row: ScheduleStopTimeRow) {
+    return `${row.train_uid}_${toYYYYMMDD(Temporal.PlainDate.from(row.runs_from))}_${toYYYYMMDD(Temporal.PlainDate.from(row.runs_to))}`;
+  }
 
   /**
    * Take a stream of ScheduleStopTimeRow, turn them into Schedule objects and add the result to the schedules
@@ -140,7 +145,7 @@ export class ScheduleBuilder {
     }
 
     return {
-      trip_id: row.id,
+      trip_id: this.getTripId(row),
       arrival_time: arrival,
       departure_time: departure,
       stop_id: row.crs_code,

--- a/test/gtfs/command/ApplyOverlays.spec.ts
+++ b/test/gtfs/command/ApplyOverlays.spec.ts
@@ -1,5 +1,4 @@
-import * as chai from "chai";
-import {describe, it, expect} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {STP} from "../../../src/gtfs/native/OverlayRecord";
 import {applyOverlays} from "../../../src/gtfs/command/ApplyOverlays";
 import {mergeSchedules} from "../../../src/gtfs/command/MergeSchedules";
@@ -7,7 +6,7 @@ import {schedule} from "./MergeSchedules.spec";
 
 describe("ApplyOverlays", () => {
 
-  it("adds exclude days for short overlays", () => {
+  it("adds exclude days for overlays", () => {
     const baseSchedules = [
       schedule(1, "A", "2017-01-01", "2017-01-31"),
       schedule(2, "A", "2017-01-05", "2017-01-07", STP.Overlay, { 0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1 })
@@ -39,8 +38,8 @@ describe("ApplyOverlays", () => {
     const schedules = applyOverlays(baseSchedules);
 
     expect(schedules["A"][0].calendar.runsFrom.equals("20170101")).to.be.true;
-    expect(schedules["A"][0].calendar.runsTo.equals("20170114")).to.be.true;
-    expect(schedules["A"][1].calendar.runsFrom.equals("20170216")).to.be.true;
+    expect(schedules["A"][0].calendar.runsTo.equals("20170131")).to.be.true;
+    expect(schedules["A"][1].calendar.runsFrom.equals("20170201")).to.be.true;
     expect(schedules["A"][1].calendar.runsTo.equals("20170228")).to.be.true;
     expect(schedules["A"][2].calendar.runsFrom.equals("20170115")).to.be.true;
     expect(schedules["A"][2].calendar.runsTo.equals("20170215")).to.be.true;
@@ -58,28 +57,15 @@ describe("ApplyOverlays", () => {
     expect(schedules["A"][1]).to.equal(nolay);
   });
 
-  it("applies a short overlay", () => {
+  it("applies an overlay", () => {
     const perm = schedule(1, "A", "2017-01-01", "2017-01-31");
-    const short = schedule(2, "A", "2017-01-05", "2017-01-07");
+    const overlay = schedule(2, "A", "2017-01-05", "2017-01-07");
 
-    const schedules = applyOverlays([perm, short]);
+    const schedules = applyOverlays([perm, overlay]);
 
     expect(schedules["A"][0]).not.to.equal(perm);
     expect(schedules["A"][0].tuid).to.equal(perm.tuid);
-  });
-
-  it("applies a long overlay", () => {
-    const perm = schedule(1, "A", "2017-01-01", "2017-01-31");
-    const long = schedule(2, "A", "2017-01-02", "2017-01-30");
-
-    const schedules = applyOverlays([perm, long]);
-    const [s1, s2, s3] = schedules["A"];
-
-    expect(s1).not.to.equal(perm);
-    expect(s1.tuid).to.equal(perm.tuid);
-    expect(s2).not.to.equal(perm);
-    expect(s2.tuid).to.equal(perm.tuid);
-    expect(s3).to.equal(long);
+    expect(schedules["A"][1]).to.equal(overlay);
   });
 
   it("removes cancellations", () => {

--- a/test/gtfs/command/MergeSchedules.spec.ts
+++ b/test/gtfs/command/MergeSchedules.spec.ts
@@ -8,26 +8,6 @@ import {StopTime} from "../../../src/gtfs/file/StopTime";
 import {Schedule} from "../../../src/gtfs/native/Schedule";
 import {RouteType} from "../../../src/gtfs/file/Route";
 
-describe("MergeSchedules", () => {
-
-  it("merges schedules where they are the same", () => {
-    const baseSchedules = [
-      schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent),
-      schedule(2, "A", "2017-02-01", "2017-02-28", STP.Permanent),
-      schedule(3, "B", "2017-01-02", "2017-03-15", STP.Permanent),
-      schedule(4, "A", "2017-01-15", "2017-02-15", STP.Overlay),
-    ];
-
-    const schedules = mergeSchedules(applyOverlays(baseSchedules));
-
-    expect(schedules[0].calendar.runsFrom.equals("20170101")).to.be.true;
-    expect(schedules[0].calendar.runsTo.equals("20170228")).to.be.true;
-    expect(schedules[1].calendar.runsFrom.equals("20170102")).to.be.true;
-    expect(schedules[1].calendar.runsTo.equals("20170315")).to.be.true;
-  });
-
-});
-
 const ALL_DAYS: Days = { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
 
 export function schedule(id: number,

--- a/test/gtfs/command/MergeSchedules.spec.ts
+++ b/test/gtfs/command/MergeSchedules.spec.ts
@@ -1,4 +1,3 @@
-import * as chai from "chai";
 import {describe, it, expect} from 'vitest';
 import {STP, TUID} from "../../../src/gtfs/native/OverlayRecord";
 import {mergeSchedules} from "../../../src/gtfs/command/MergeSchedules";
@@ -8,7 +7,83 @@ import {StopTime} from "../../../src/gtfs/file/StopTime";
 import {Schedule} from "../../../src/gtfs/native/Schedule";
 import {RouteType} from "../../../src/gtfs/file/Route";
 
+describe("MergeSchedules", () => {
+
+  it("gives every schedule a trip ID derived from its TUID and date range", () => {
+    const schedules = mergeSchedules(applyOverlays([
+      schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent),
+      schedule(2, "B", "2017-01-02", "2017-03-15", STP.Permanent),
+    ]));
+
+    expect(schedules.map(s => s.tripId)).to.deep.equal([
+      "A_20170101_20170131",
+      "B_20170102_20170315"
+    ]);
+  });
+
+  it("keeps the trip ID when an overlay covering the whole schedule is withdrawn", () => {
+    const overlaid = mergeSchedules(applyOverlays([
+      schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent),
+      schedule(2, "A", "2017-01-01", "2017-01-31", STP.Overlay),
+    ]));
+
+    const withdrawn = mergeSchedules(applyOverlays([
+      schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent),
+    ]));
+
+    expect(overlaid).to.have.length(1);
+    expect(overlaid[0].stp).to.equal(STP.Overlay);
+    expect(withdrawn).to.have.length(1);
+    expect(withdrawn[0].stp).to.equal(STP.Permanent);
+    expect(withdrawn[0].tripId).to.equal(overlaid[0].tripId);
+  });
+
+  it("suffixes a duplicate trip ID rather than failing the build", () => {
+    const duplicate = () => schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent, ALL_DAYS, [
+      stopTime("AAA", "A_20170101_20170131"),
+      stopTime("BBB", "A_20170101_20170131"),
+    ]);
+
+    const schedules = mergeSchedules({ "A": [duplicate(), duplicate()] });
+
+    expect(schedules).to.have.length(2);
+    expect(schedules[0].stopTimes[0].trip_id).to.equal("A_20170101_20170131");
+    expect(schedules[1].stopTimes[0].trip_id).to.equal("A_20170101_20170131_2");
+  });
+
+  it("keeps the stop times pointing at the trip they belong to", () => {
+    const stale = schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent, ALL_DAYS, [
+      stopTime("AAA", "A_20170101_20171231"),
+      stopTime("BBB", "A_20170101_20171231"),
+    ]);
+
+    const [merged] = mergeSchedules({ "A": [stale] });
+
+    expect(merged.tripId).to.equal("A_20170101_20170131");
+    expect(merged.stopTimes.map(s => s.trip_id)).to.deep.equal([
+      "A_20170101_20170131",
+      "A_20170101_20170131"
+    ]);
+  });
+
+});
+
 const ALL_DAYS: Days = { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
+
+function stopTime(stop: string, tripId: string): StopTime {
+  return {
+    trip_id: tripId,
+    arrival_time: "10:00",
+    departure_time: "10:00",
+    stop_id: stop,
+    stop_sequence: 1,
+    stop_headsign: "",
+    pickup_type: 0,
+    drop_off_type: 0,
+    shape_dist_traveled: null,
+    timepoint: 0,
+  };
+}
 
 export function schedule(id: number,
                          tuid: TUID,

--- a/test/gtfs/native/Association.spec.ts
+++ b/test/gtfs/native/Association.spec.ts
@@ -1,5 +1,4 @@
-import * as chai from "chai";
-import {describe, it, expect} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {Days, ScheduleCalendar} from "../../../src/gtfs/native/ScheduleCalendar";
 import {STP} from "../../../src/gtfs/native/OverlayRecord";
 import {StopTime} from "../../../src/gtfs/file/StopTime";
@@ -57,19 +56,19 @@ describe("Association", () => {
     expect(result.tuid).to.equal("A_B");
     expect(result.stopTimes[0].stop_id).to.equal("PDW");
     expect(result.stopTimes[0].stop_sequence).to.equal(1);
-    expect(result.stopTimes[0].trip_id).to.equal(2);
+    expect(result.stopTimes[0].trip_id).to.equal("A_B_20170710_20170716");
     expect(result.stopTimes[1].stop_id).to.equal("ASH");
     expect(result.stopTimes[1].stop_sequence).to.equal(2);
-    expect(result.stopTimes[1].trip_id).to.equal(2);
+    expect(result.stopTimes[1].trip_id).to.equal("A_B_20170710_20170716");
     expect(result.stopTimes[2].stop_id).to.equal("DOV");
     expect(result.stopTimes[2].stop_sequence).to.equal(3);
-    expect(result.stopTimes[2].trip_id).to.equal(2);
+    expect(result.stopTimes[2].trip_id).to.equal("A_B_20170710_20170716");
     expect(result.stopTimes[3].stop_id).to.equal("A");
     expect(result.stopTimes[3].stop_sequence).to.equal(4);
-    expect(result.stopTimes[3].trip_id).to.equal(2);
+    expect(result.stopTimes[3].trip_id).to.equal("A_B_20170710_20170716");
     expect(result.stopTimes[4].stop_id).to.equal("B");
     expect(result.stopTimes[4].stop_sequence).to.equal(5);
-    expect(result.stopTimes[4].trip_id).to.equal(2);
+    expect(result.stopTimes[4].trip_id).to.equal("A_B_20170710_20170716");
   });
 
   it("applies overnight splits", () => {
@@ -181,25 +180,25 @@ describe("Association", () => {
     expect(result.tuid).to.equal("B_A");
     expect(result.stopTimes[0].stop_id).to.equal("A");
     expect(result.stopTimes[0].stop_sequence).to.equal(1);
-    expect(result.stopTimes[0].trip_id).to.equal(2);
+    expect(result.stopTimes[0].trip_id).to.equal("B_A_20170710_20170716");
     expect(result.stopTimes[1].stop_id).to.equal("B");
     expect(result.stopTimes[1].stop_sequence).to.equal(2);
-    expect(result.stopTimes[1].trip_id).to.equal(2);
+    expect(result.stopTimes[1].trip_id).to.equal("B_A_20170710_20170716");
     expect(result.stopTimes[2].stop_id).to.equal("C");
     expect(result.stopTimes[2].stop_sequence).to.equal(3);
-    expect(result.stopTimes[2].trip_id).to.equal(2);
+    expect(result.stopTimes[2].trip_id).to.equal("B_A_20170710_20170716");
     expect(result.stopTimes[3].stop_id).to.equal("DOV");
     expect(result.stopTimes[3].stop_sequence).to.equal(4);
-    expect(result.stopTimes[3].trip_id).to.equal(2);
+    expect(result.stopTimes[3].trip_id).to.equal("B_A_20170710_20170716");
     expect(result.stopTimes[4].stop_id).to.equal("ASH");
     expect(result.stopTimes[4].stop_sequence).to.equal(5);
-    expect(result.stopTimes[4].trip_id).to.equal(2);
+    expect(result.stopTimes[4].trip_id).to.equal("B_A_20170710_20170716");
     expect(result.stopTimes[5].stop_id).to.equal("PDW");
     expect(result.stopTimes[5].stop_sequence).to.equal(6);
-    expect(result.stopTimes[5].trip_id).to.equal(2);
+    expect(result.stopTimes[5].trip_id).to.equal("B_A_20170710_20170716");
     expect(result.stopTimes[6].stop_id).to.equal("TON");
     expect(result.stopTimes[6].stop_sequence).to.equal(7);
-    expect(result.stopTimes[6].trip_id).to.equal(2);
+    expect(result.stopTimes[6].trip_id).to.equal("B_A_20170710_20170716");
   });
 
   it("takes the correct departure time for joins", () => {
@@ -260,23 +259,16 @@ describe("Association", () => {
       STP.Overlay
     );
 
-    const [result, before, after, ex1, ex2] = association1.apply(base, assoc, idGenerator());
+    const [result, other] = association1.apply(base, assoc, idGenerator());
 
     expect(result.tuid).to.equal("A_B");
     expect(result.calendar.runsFrom.equals("2017-07-20")).to.equal(true);
     expect(result.calendar.runsTo.equals("2017-08-16")).to.equal(true);
-    expect(before.tuid).to.equal("B");
-    expect(before.calendar.runsFrom.equals("2017-07-10")).to.equal(true);
-    expect(before.calendar.runsTo.equals("2017-07-19")).to.equal(true);
-    expect(after.tuid).to.equal("B");
-    expect(after.calendar.runsFrom.equals("2017-08-17")).to.equal(true);
-    expect(after.calendar.runsTo.equals("2017-09-16")).to.equal(true);
-    expect(ex1.tuid).to.equal("B");
-    expect(ex1.calendar.runsFrom.equals("2017-08-01")).to.equal(true);
-    expect(ex1.calendar.runsTo.equals("2017-08-01")).to.equal(true);
-    expect(ex2.tuid).to.equal("B");
-    expect(ex2.calendar.runsFrom.equals("2017-08-05")).to.equal(true);
-    expect(ex2.calendar.runsTo.equals("2017-08-05")).to.equal(true);
+    expect(other.tuid).to.equal("B");
+    expect(other.calendar.runsFrom.equals("2017-07-10")).to.equal(true);
+    expect(other.calendar.runsTo.equals("2017-09-16")).to.equal(true);
+    expect(other.calendar.excludeDays).to.include.all.keys("20170720", "20170816");
+    expect(other.calendar.excludeDays).to.not.have.any.keys("20170801", "20170805");
   });
 
   it("does not create a copy of the associated schedule for dates when it does not run", () => {
@@ -349,7 +341,7 @@ describe("Association", () => {
 const ALL_DAYS: Days = { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
 const WEEKDAYS: Days = { 0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 0 };
 
-function stop(stopSequence: number, location: CRS, time: string, tripId: number = 1): StopTime {
+function stop(stopSequence: number, location: CRS, time: string, tripId: string = "Z00000_20270101_20270101"): StopTime {
   return {
     trip_id: tripId,
     arrival_time: time,

--- a/test/gtfs/native/Association.spec.ts
+++ b/test/gtfs/native/Association.spec.ts
@@ -5,6 +5,7 @@ import {StopTime} from "../../../src/gtfs/file/StopTime";
 import {Schedule} from "../../../src/gtfs/native/Schedule";
 import {CRS} from "../../../src/gtfs/file/Stop";
 import {Association, AssociationType, DateIndicator} from "../../../src/gtfs/native/Association";
+import {applyOverlays} from "../../../src/gtfs/command/ApplyOverlays";
 import {schedule} from "../command/MergeSchedules.spec";
 
 describe("Association", () => {
@@ -269,6 +270,25 @@ describe("Association", () => {
     expect(other.calendar.runsTo.equals("2017-09-16")).to.equal(true);
     expect(other.calendar.excludeDays).to.include.all.keys("20170720", "20170816");
     expect(other.calendar.excludeDays).to.not.have.any.keys("20170801", "20170805");
+
+    expect(result.calendar.excludeDays).to.include.all.keys("20170801", "20170805");
+  });
+
+  it("keeps the stop time trip ID in step with the calendar for previous day associations", () => {
+    const base = schedule(1, "A", "2017-07-10", "2017-07-16", STP.Overlay, ALL_DAYS, [
+      stop(1, "TON", "10:00"),
+      stop(2, "ASH", "12:00"),
+    ]);
+
+    const assoc = schedule(2, "B", "2017-07-10", "2017-07-16", STP.Overlay, ALL_DAYS, [
+      stop(1, "ASH", "12:05"),
+      stop(2, "DOV", "13:00"),
+    ]);
+
+    const association1 = association(base, assoc, AssociationType.Split, "ASH", DateIndicator.Previous);
+    const [result] = association1.apply(base, assoc, idGenerator());
+
+    expect(result.stopTimes[0].trip_id).to.equal(result.tripId);
   });
 
   it("does not create a copy of the associated schedule for dates when it does not run", () => {
@@ -334,6 +354,29 @@ describe("Association", () => {
     expect(results).to.have.length(1);
     expect(results[0].tuid).to.equal("A_B");
     expect(results[0].calendar.isEmpty).to.equal(false);
+  });
+
+
+  it("cancels only the association at the location the cancellation names", () => {
+    const calendar = new ScheduleCalendar(
+      Temporal.PlainDate.from("2026-12-14"), Temporal.PlainDate.from("2027-05-13"), ALL_DAYS
+    );
+
+    const divideAtBarnham = new Association(
+      1, "A", "B", "BAA", DateIndicator.Same, AssociationType.Split, calendar, STP.Permanent
+    );
+    const divideAtHorsham = new Association(
+      2, "A", "B", "HRH", DateIndicator.Same, AssociationType.Split, calendar, STP.Permanent
+    );
+    const cancelAtBarnham = new Association(
+      3, "A", "B", "BAA", DateIndicator.Same, AssociationType.NA, calendar, STP.Cancellation
+    );
+
+    const index = applyOverlays([divideAtBarnham, divideAtHorsham, cancelAtBarnham]);
+    const surviving = Object.values(index).flat();
+
+    expect(surviving).to.have.length(1);
+    expect(surviving[0].assocLocation).to.equal("HRH");
   });
 
 });

--- a/test/gtfs/native/Schedule.spec.ts
+++ b/test/gtfs/native/Schedule.spec.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from 'vitest';
+import {STP} from "../../../src/gtfs/native/OverlayRecord";
+import {Days, ScheduleCalendar} from "../../../src/gtfs/native/ScheduleCalendar";
+import {schedule} from "../command/MergeSchedules.spec";
+import {StopTime} from "../../../src/gtfs/file/StopTime";
+
+describe("Schedule", () => {
+
+  it("does not share stop times with its clones", () => {
+    const original = schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent, ALL_DAYS, [
+      stop("AAA", "00:30")
+    ]);
+
+    const clone = original.clone(original.calendar.shiftBackward(), 2);
+    clone.stopTimes[0].departure_time = "24:30";
+
+    expect(original.stopTimes[0].departure_time).to.equal("00:30");
+  });
+
+  it("identifies a trip by TUID, STP indicator and date range", () => {
+    const permanent = schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent);
+    const overlay = schedule(2, "A", "2017-01-01", "2017-01-31", STP.Overlay);
+
+    expect(permanent.tripId).to.equal("A_20170101_20170131");
+    expect(overlay.tripId).to.equal("A_20170101_20170131");
+  });
+
+});
+
+const ALL_DAYS: Days = { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
+
+function stop(stopId: string, time: string): StopTime {
+  return {
+    trip_id: "A_20170101_20170131",
+    arrival_time: time,
+    departure_time: time,
+    stop_id: stopId,
+    stop_sequence: 1,
+    stop_headsign: "",
+    pickup_type: 0,
+    drop_off_type: 0,
+    shape_dist_traveled: null,
+    timepoint: 0,
+  };
+}

--- a/test/gtfs/native/ScheduleCalendar.spec.ts
+++ b/test/gtfs/native/ScheduleCalendar.spec.ts
@@ -1,4 +1,3 @@
-import * as chai from "chai";
 import {describe, it, expect} from 'vitest';
 import {Days, OverlapType, ScheduleCalendar} from "../../../src/gtfs/native/ScheduleCalendar";
 
@@ -11,9 +10,9 @@ describe("ScheduleCalendar", () => {
     const overlay = calendar("2017-01-31", "2017-02-07");
     const nolay = calendar("2017-02-05", "2017-02-07");
 
-    expect(perm.getOverlap(underlay)).to.deep.equal(OverlapType.Long);
-    expect(perm.getOverlap(innerlay)).to.deep.equal(OverlapType.Short);
-    expect(perm.getOverlap(overlay)).to.deep.equal(OverlapType.Short);
+    expect(perm.getOverlap(underlay)).to.deep.equal(OverlapType.Overlap);
+    expect(perm.getOverlap(innerlay)).to.deep.equal(OverlapType.Overlap);
+    expect(perm.getOverlap(overlay)).to.deep.equal(OverlapType.Overlap);
     expect(perm.getOverlap(nolay)).to.deep.equal(OverlapType.None);
   });
 
@@ -24,7 +23,7 @@ describe("ScheduleCalendar", () => {
 
     expect(weekday.getOverlap(weekend)).to.deep.equal(OverlapType.None);
     expect(weekend.getOverlap(weekday)).to.deep.equal(OverlapType.None);
-    expect(weekday.getOverlap(tuesday)).to.deep.equal(OverlapType.Short);
+    expect(weekday.getOverlap(tuesday)).to.deep.equal(OverlapType.Overlap);
   });
 
   it("detects short overlays", () => {
@@ -34,16 +33,16 @@ describe("ScheduleCalendar", () => {
     // full two weeks
     const long = calendar("2017-01-11", "2017-01-19");
 
-    expect(perm.getOverlap(short)).to.deep.equal(OverlapType.Short);
-    expect(perm.getOverlap(long)).to.deep.equal(OverlapType.Long);
+    expect(perm.getOverlap(short)).to.deep.equal(OverlapType.Overlap);
+    expect(perm.getOverlap(long)).to.deep.equal(OverlapType.Overlap);
   });
 
   it("adds exclude days", () => {
     const perm = calendar("2017-01-01", "2017-01-31");
     const overlay = calendar("2017-01-20", "2017-01-21");
 
-    const [calendar1] = perm.addExcludeDays(overlay);
-    const excludeDays = Object.keys(calendar1.excludeDays);
+    const calendar1 = perm.addExcludeDays(overlay);
+    const excludeDays = Object.keys(calendar1!.excludeDays);
 
     expect(excludeDays[0]).to.equal("20170120");
     expect(excludeDays[1]).to.equal("20170121");
@@ -54,13 +53,18 @@ describe("ScheduleCalendar", () => {
     const underlay = calendar("2017-01-01", "2017-01-07");
     const overlay = calendar("2017-01-30", "2017-02-07");
 
-    const [calendar1] = perm.addExcludeDays(underlay);
-    const [calendar2] = calendar1.addExcludeDays(overlay);
-    const excludeDays = Object.keys(calendar2.excludeDays);
+    const calendar1 = perm.addExcludeDays(underlay);
+    const calendar2 = calendar1!.addExcludeDays(overlay);
+    const excludeDays = Object.keys(calendar2!.excludeDays);
 
-    expect(excludeDays.length).to.equal(0);
-    expect(calendar2.runsFrom.equals("20170108")).to.be.true;
-    expect(calendar2.runsTo.equals("20170129")).to.be.true;
+    expect(excludeDays.length).to.equal(5);
+    expect(calendar2!.runsFrom.equals("20170105")).to.be.true;
+    expect(calendar2!.runsTo.equals("20170131")).to.be.true;
+    expect(excludeDays[0]).to.equal("20170105");
+    expect(excludeDays[1]).to.equal("20170106");
+    expect(excludeDays[2]).to.equal("20170107");
+    expect(excludeDays[3]).to.equal("20170130");
+    expect(excludeDays[4]).to.equal("20170131");
   });
 
   it("adding exclude days might remove the schedule", () => {
@@ -68,93 +72,26 @@ describe("ScheduleCalendar", () => {
     const c1 = calendar("2017-01-01", "2017-01-07", { 0: 1, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 });
     const c2 = calendar("2017-01-08", "2017-01-15", { 0: 1, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 });
 
-    const [calendar1] = perm.addExcludeDays(c1);
+    const calendar1 = perm.addExcludeDays(c1)!;
 
-    expect(calendar1.runsFrom.equals("20170108")).to.be.true;
+    expect(calendar1.runsFrom.equals("20170101")).to.be.true;
     expect(calendar1.runsTo.equals("20170115")).to.be.true;
+
+    const excludeDays = Object.keys(calendar1!.excludeDays);
+    
+    expect(excludeDays.length).to.equal(1);
+    expect(excludeDays[0]).to.equal("20170101");
 
     const calendars = calendar1.addExcludeDays(c2);
 
-    expect(calendars.length).to.equal(0);
+    expect(calendars).null;
   });
 
-  it("divides around a date range spanning the beginning", () => {
-    const perm = calendar("2017-01-05", "2017-01-31");
-    const underlay = calendar("2017-01-01", "2017-01-07");
-
-    const calendars = perm.divideAround(underlay);
-    expect(calendars[0].runsFrom.equals("2017-01-08")).to.be.true;
-    expect(calendars[0].runsTo.equals("2017-01-31")).to.be.true;
-  });
-
-  it("divides around a date range spanning the end", () => {
-    const perm = calendar("2017-01-05", "2017-01-31");
-    const underlay = calendar("2017-01-29", "2017-02-07");
-
-    const calendars = perm.divideAround(underlay);
-    expect(calendars[0].runsFrom.equals("2017-01-05")).to.be.true;
-    expect(calendars[0].runsTo.equals("2017-01-28")).to.be.true;
-  });
-
-  it("divides around a date range and creates the smallest date range possible", () => {
-    // this is based of a real world scenario using the C29405
-    const perm = calendar("2017-05-26", "2017-06-30", { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0});
-    const underlay = calendar("2017-06-26", "2017-06-30");
-
-    const calendars = perm.divideAround(underlay);
-
-    expect(calendars[0].runsFrom.equals("2017-05-26")).to.be.true;
-    expect(calendars[0].runsTo.equals("2017-06-23")).to.be.true;
-  });
-
-  it("divides around a date range in the middle", () => {
-    const perm = calendar("2017-01-05", "2017-01-31");
-    const underlay = calendar("2017-01-15", "2017-01-20");
-
-    const calendars = perm.divideAround(underlay);
-    expect(calendars[0].runsFrom.equals("2017-01-05")).to.be.true;
-    expect(calendars[0].runsTo.equals("2017-01-14")).to.be.true;
-    expect(calendars[1].runsFrom.equals("2017-01-21")).to.be.true;
-    expect(calendars[1].runsTo.equals("2017-01-31")).to.be.true;
-  });
-
-  it("partially degrades the services", () => {
-    const perm = calendar("2017-01-01", "2017-01-31");
-    // Wed + Thurs for two weeks
-    const underlay = calendar("2017-01-11", "2017-01-19", { 0: 0, 1: 0, 2: 0, 3: 1, 4: 1, 5: 0, 6: 0 });
-
-    const calendars = perm.divideAround(underlay);
-    expect(calendars[0].runsFrom.equals("2017-01-01")).to.be.true;
-    expect(calendars[0].runsTo.equals("2017-01-10")).to.be.true;
-    expect(calendars[1].runsFrom.equals("2017-01-20")).to.be.true;
-    expect(calendars[1].runsTo.equals("2017-01-31")).to.be.true;
-    expect(calendars[2].days).to.deep.equal({0: 1, 1: 1, 2: 1, 3: 0, 4: 0, 5: 1, 6: 1});
-    // days where the service is not running are removed
-    expect(calendars[2].runsFrom.equals("2017-01-13")).to.be.true;
-    expect(calendars[2].runsTo.equals("2017-01-17")).to.be.true;
-  });
-
-  it("degrades the service to the point where it doesn't run", () => {
-    // Monday + Friday service
-    const perm = calendar("2017-01-02", "2017-01-30", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    // Remove a Monday
-    const underlay = calendar("2017-01-15", "2017-01-19", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 });
-
-    const calendars = perm.divideAround(underlay);
-
-    expect(calendars.length).to.equal(2);
-    expect(calendars[0].runsFrom.equals("2017-01-02")).to.be.true;
-    expect(calendars[0].runsTo.equals("2017-01-13")).to.be.true;
-    expect(calendars[1].runsFrom.equals("2017-01-20")).to.be.true;
-    expect(calendars[1].runsTo.equals("2017-01-30")).to.be.true;
-  });
-
-  it("does not tighten the date range past its bounds when there are no operating days in the range", () => {
+  it("terminates when all dates have been removed from the schedule", () => {
     const saturdayOnly = calendar("2023-11-20", "2023-11-24", { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 1 });
     const result = saturdayOnly.clone(Temporal.PlainDate.from("2023-11-20"), Temporal.PlainDate.from("2023-11-24"));
 
     expect(result.isEmpty).to.be.true;
-    expect(result.runsFrom.since(result.runsTo).days).to.equal(1);
   });
 
   it("terminates when the schedule has no operating days at all", () => {
@@ -162,66 +99,6 @@ describe("ScheduleCalendar", () => {
     const result = noDays.clone(Temporal.PlainDate.from("2023-11-20"), Temporal.PlainDate.from("2023-11-24"));
 
     expect(result.isEmpty).to.be.true;
-  });
-
-  it("detects when a calendar can be merged with another", () => {
-    // Monday + Friday service
-    const c1 = calendar("2017-07-03", "2017-07-14", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    const c2 = calendar("2017-07-17", "2017-07-21", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    const c3 = calendar("2017-10-13", "2017-10-16", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-
-    expect(c1.canMerge(c2)).to.be.true;
-    expect(c1.canMerge(c3)).to.be.false;
-  });
-
-  it("can merge with another calendar", () => {
-    // Monday + Friday service
-    const c1 = calendar("2017-07-03", "2017-07-14", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    c1.excludeDays["20170710"] = Temporal.PlainDate.from("20170710");
-
-    const c2 = calendar("2017-07-17", "2017-07-28", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    c2.excludeDays["20170721"] = Temporal.PlainDate.from("20170721");
-
-    const c3 = c1.merge(c2);
-
-    expect(c3.runsFrom.equals(c1.runsFrom)).to.be.true;
-    expect(c3.runsTo.equals(c2.runsTo)).to.be.true;
-    expect(c3.excludeDays["20170710"]).to.not.be.undefined;
-    expect(c3.excludeDays["20170721"]).to.not.be.undefined;
-  });
-
-  it("can merge with an overlapping calendar", () => {
-    // Monday + Friday service
-    const c1 = calendar("2017-07-03", "2017-07-28", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    c1.excludeDays["20170717"] = Temporal.PlainDate.from("20170717");
-    c1.excludeDays["20170721"] = Temporal.PlainDate.from("20170721");
-
-    const c2 = calendar("2017-07-17", "2017-07-28", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    c2.excludeDays["20170721"] = Temporal.PlainDate.from("20170721");
-
-    const c3 = c1.merge(c2);
-
-    expect(c3.runsFrom.equals(c1.runsFrom)).to.be.true;
-    expect(c3.runsTo.equals(c1.runsTo)).to.be.true;
-    expect(Object.keys(c3.excludeDays).length).to.equal(1);
-    expect(c3.excludeDays["20170721"]).to.not.be.undefined;
-  });
-
-  it("can bridge the gap between a merging service with exclude days", () => {
-    // Monday + Friday service
-    const c1 = calendar("2017-07-03", "2017-07-14", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    c1.excludeDays["20170710"] = Temporal.PlainDate.from("20170710");
-
-    const c2 = calendar("2017-07-21", "2017-07-28", { 0: 0, 1: 1, 2: 0, 3: 0, 4: 0, 5: 1, 6: 0 });
-    c2.excludeDays["20170721"] = Temporal.PlainDate.from("20170721");
-
-    const c3 = c1.merge(c2);
-
-    expect(c3.runsFrom.equals(c1.runsFrom)).to.be.true;
-    expect(c3.runsTo.equals(c2.runsTo)).to.be.true;
-    expect(c3.excludeDays["20170710"]).to.not.be.undefined;
-    expect(c3.excludeDays["20170717"]).to.not.be.undefined;
-    expect(c3.excludeDays["20170721"]).to.not.be.undefined;
   });
 
   it("shift forward", () => {


### PR DESCRIPTION
Based off #121 

I built a 3-month feed both ways and diffed the (date × TUID × stopping pattern) sets. `master` runs services on 22 date/TUID pairs where a `C` record cancels them; this branch runs none of them. The cause is `Association.apply` cloning the associated schedule onto each of the association's exclude days without checking the date is inside the schedule's own validity - 154 times in a 3-month build. Deleting that is the right call.

Six things I found:

1. `Association.mergeSchedules` builds `newCalendar`, uses it for the trip ID, then passes a different calendar to the `Schedule`. Merged trips run on days the association is cancelled while both trains also run separately - 382 duplicated trips. Passing `newCalendar` fixes it, and the `P` date-indicator desync with it.
2. `tsc` fails - `Association.clone` returns `Association`, not `this`. Blocks `prepublishOnly`.
3. Trip ID drops the STP indicator, so it isn't the CIF key. 35 permanent/overlay pairs in a current feed share a date range. Now `TUID_STP_from_to`.
4. `mergeSchedules` throws on a collision, failing the whole build on a data quirk. Now suffixes and logs.
5. `Schedule.clone` shares stop time objects, and `addLateNightServices` mutates them in place.
6. Restored the `MergeSchedules` suite - deleting its only `describe` left the file with no tests, which is what's failing CI

