### PR TITLE
C5: Rail Data Marketplace credential path

### DIFF
--- a/.changeset/rail-data-marketplace-credentials.md
+++ b/.changeset/rail-data-marketplace-credentials.md
@@ -1,0 +1,15 @@
+---
+"dtd2mysql": patch
+---
+
+Say where feed credentials come from, and make the transport replaceable.
+
+The National Rail open data portal was retired in early 2026 and an account for
+the Timetable and Fares feeds now comes from Rail Data Marketplace. The SFTP
+host is unchanged, so only issuance moved - but a missing variable failed at the
+handshake with nothing to suggest the portal you were looking at no longer
+exists. It now names raildata.org.uk, and so does the README.
+
+`DownloadCommand` depends on a `FeedTransport` that lists and fetches, rather
+than on the SFTP client, so a Rail Data Marketplace API implementation can be
+added without touching it.

--- a/apps/dtd2mysql/README.md
+++ b/apps/dtd2mysql/README.md
@@ -77,6 +77,12 @@ SFTP_PASSWORD=dtd_password
 SFTP_HOSTNAME=dtd_hostname (this will default to dtd.atocrsp.org)
 ```
 
+**Where the credentials come from changed in early 2026.** The National Rail open data portal at
+`opendata.nationalrail.co.uk` was retired; an account for the Timetable and Fares feeds now comes
+from a subscription on [Rail Data Marketplace](https://raildata.org.uk). The SFTP host is unchanged
+and still serves the files - only issuance moved - so an existing setup keeps working and a new one
+starts at RDM rather than at the old portal.
+
 There is a command for each feed
 
 ```

--- a/apps/dtd2mysql/src/container.ts
+++ b/apps/dtd2mysql/src/container.ts
@@ -10,6 +10,7 @@ import {
   DownloadAndProcessCommand,
   DownloadCommand,
   DownloadFileCommand,
+  feedCredentials,
   PromiseSFTP
 } from "@gb-rail/dtd-source";
 import {CLICommand} from "./cli/CLICommand";
@@ -128,45 +129,7 @@ const getImportFeedCommand = once((feed: "fares" | "routeing" | "timetable" | "n
   )
 );
 
-const getSFTP = once((_: null): Promise<PromiseSFTP> =>
-  PromiseSFTP.connect({
-    host: process.env.SFTP_HOSTNAME || "dtd.atocrsp.org",
-    username: process.env.SFTP_USERNAME,
-    password: process.env.SFTP_PASSWORD,
-    algorithms: {
-      kex: [
-        "diffie-hellman-group1-sha1",
-        "ecdh-sha2-nistp256",
-        "ecdh-sha2-nistp384",
-        "ecdh-sha2-nistp521",
-        "diffie-hellman-group-exchange-sha256",
-        "diffie-hellman-group14-sha1"
-      ],
-      cipher: [
-        "3des-cbc",
-        "aes128-ctr",
-        "aes192-ctr",
-        "aes256-ctr",
-        "aes128-gcm",
-        "aes128-gcm@openssh.com",
-        "aes256-gcm",
-        "aes256-gcm@openssh.com"
-      ],
-      serverHostKey: [
-        "ssh-dss",
-        "ssh-rsa",
-        "ecdsa-sha2-nistp256",
-        "ecdsa-sha2-nistp384",
-        "ecdsa-sha2-nistp521"
-      ],
-      hmac: [
-        "hmac-sha2-256",
-        "hmac-sha2-512",
-        "hmac-sha1"
-      ]
-    }
-  })
-);
+const getSFTP = once((_: null): Promise<PromiseSFTP> => PromiseSFTP.open(feedCredentials()));
 
 const getDownloadCommand = once(async (directory: string) =>
   new DownloadCommand(

--- a/docs/restructure.md
+++ b/docs/restructure.md
@@ -1311,11 +1311,26 @@ filename - as text every `RJTTC` sorts before every `RJTTF`, which would apply t
 incrementals that amend it - and starting at the last refresh matters because a directory that feeds
 are downloaded into accumulates more than one cycle. E2 wants the same rule.
 
-**C5 · Rail Data Marketplace credential path** *(depends A5)*
-The NRDP (`opendata.nationalrail.co.uk`) was retired in early 2026; tokens now come from Rail Data
-Marketplace (`raildata.org.uk`). The SFTP host still serves files but credential issuance has moved.
-`dtd-source` transport becomes pluggable (SFTP today, RDM API when needed); credentials resolved
-from env in one place; README updated.
+**C5 · Rail Data Marketplace credential path** *(depends A5)* — **done**
+The NRDP (`opendata.nationalrail.co.uk`) was retired in early 2026; an account now comes from a Rail
+Data Marketplace subscription (`raildata.org.uk`). The SFTP host still serves the files, so nothing
+about the transport changed - only where the username and password are obtained, which is the part
+that was undocumented and unfindable.
+
+`FeedTransport` is the seam: list and fetch, which is all downloading a feed needs. `DownloadCommand`
+depends on it rather than on `PromiseSFTP`, so an RDM API implementation can arrive without touching
+the command. `PromiseSFTP` implements it and now owns the algorithm list, which was sitting in
+`container.ts` - 30 lines of ssh2 negotiation detail in a wiring file, where the comment explaining
+why it cannot be deleted had nowhere to live.
+
+`feedCredentials()` resolves the environment in one place and **fails with an explanation rather
+than at the handshake**: a missing variable now says the credentials come from raildata.org.uk and
+not from the retired portal, which is where someone reading a bare authentication failure would
+otherwise go looking. `apps/dtd2mysql/README.md` says the same.
+
+Deliberately not done: an RDM API transport. Nothing needs one - the SFTP host serves the files -
+and writing a second implementation against an API this project does not yet call would be guessing
+at its shape. The seam is the deliverable.
 
 **C4 · `apps/dtd2postgres`** — **deferred, not in this pass** — **would close #116**
 Postgres `Storage` (DDL generation, `COPY`-based bulk load) and `PostgresTimetableSource`, plus a
@@ -1609,8 +1624,8 @@ parallel by different people without touching the core.
 
 **84 tickets** listed (B22 was found while building C2; B23, D11 and D12 came out of reviewing the
 B4–B13 batch; B24 and B25 were found by B6's validator on its first run). B3 is absorbed into T1, 24 are done — T1–T5, B0, B4, B5, B7–B9, B13, A1–A3, A5–A10,
-C1–C3, B1, B2, B6, B10–B12, B15 and B17 — B14, B16, B18, B19, B20 and B21 are resolved by #121, and A4 and C4 are deferred
-out of this pass, leaving **43 in scope**.
+C1–C3, C5, B1, B2, B6, B10–B12, B15, B17, B22 and B23 — B14, B16, B18, B19, B20 and B21 are resolved by #121, and A4 and C4 are deferred
+out of this pass, leaving **39 in scope**.
 
 ---
 

--- a/libs/dtd-source/src/Credentials.spec.ts
+++ b/libs/dtd-source/src/Credentials.spec.ts
@@ -1,0 +1,23 @@
+import {describe, it, expect} from "vitest";
+import {DTD_HOST, feedCredentials} from "./Credentials";
+
+describe("feedCredentials", () => {
+
+  it("takes the account from the environment", () => {
+    expect(feedCredentials({SFTP_USERNAME: "u", SFTP_PASSWORD: "p"}))
+      .to.deep.equal({host: DTD_HOST, username: "u", password: "p"});
+  });
+
+  it("lets the host be overridden", () => {
+    expect(feedCredentials({SFTP_USERNAME: "u", SFTP_PASSWORD: "p", SFTP_HOSTNAME: "example.org"}).host)
+      .to.equal("example.org");
+  });
+
+  it("says where credentials come from now, rather than failing at the handshake", () => {
+    // The portal that used to issue them was retired in early 2026, so someone
+    // reading a bare authentication failure would go looking in the wrong place.
+    expect(() => feedCredentials({})).to.throw(/raildata\.org\.uk/);
+    expect(() => feedCredentials({SFTP_USERNAME: "u"})).to.throw(/SFTP_PASSWORD/);
+  });
+
+});

--- a/libs/dtd-source/src/Credentials.ts
+++ b/libs/dtd-source/src/Credentials.ts
@@ -1,0 +1,33 @@
+/**
+ * Where the feed lives and who is allowed to read it.
+ *
+ * One place, because the answer changed in early 2026 and will change again.
+ * The NRDP at `opendata.nationalrail.co.uk` was retired; the SFTP host still
+ * serves the files, but the account that reaches it now comes from Rail Data
+ * Marketplace at `raildata.org.uk`. Nothing about the transport changed, only
+ * where the username and password are obtained, which is exactly why resolving
+ * them belongs somewhere a reader can find.
+ */
+export interface FeedCredentials {
+  host: string;
+  username: string;
+  password: string;
+}
+
+export const DTD_HOST = "dtd.atocrsp.org";
+
+export function feedCredentials(env: NodeJS.ProcessEnv = process.env): FeedCredentials {
+  const username = env.SFTP_USERNAME;
+  const password = env.SFTP_PASSWORD;
+
+  if (!username || !password) {
+    throw new Error(
+      "SFTP_USERNAME and SFTP_PASSWORD are needed to download a feed. They come from a Rail Data " +
+      "Marketplace subscription to the Timetable and Fares feeds - raildata.org.uk - not from the " +
+      "National Rail open data portal, which was retired in early 2026. SFTP_HOSTNAME overrides " +
+      `the host, which defaults to ${DTD_HOST}.`
+    );
+  }
+
+  return {host: env.SFTP_HOSTNAME || DTD_HOST, username, password};
+}

--- a/libs/dtd-source/src/DownloadCommand.ts
+++ b/libs/dtd-source/src/DownloadCommand.ts
@@ -1,4 +1,4 @@
-import {PromiseSFTP} from "./PromiseSFTP";
+import {FeedTransport} from "./FeedTransport";
 import {FeedCursor} from "./FeedCursor";
 import { FileEntry } from "ssh2";
 
@@ -6,7 +6,7 @@ export class DownloadCommand {
 
   constructor(
     private readonly cursor: FeedCursor,
-    private readonly sftp: PromiseSFTP,
+    private readonly transport: FeedTransport,
     private readonly directory: string
   ) {}
 
@@ -16,7 +16,7 @@ export class DownloadCommand {
   public async run(argv: string[]): Promise<string[]> {
     const outputDirectory = argv[3] || "/tmp/";
     const [remoteFiles, lastProcessedFile] = await Promise.all([
-      this.sftp.readdir(this.directory),
+      this.transport.readdir(this.directory),
       this.cursor.getLastProcessedFile()
     ]);
 
@@ -31,14 +31,14 @@ export class DownloadCommand {
 
     try {
       await Promise.all(
-        files.map(f => this.sftp.fastGet(this.directory + f, outputDirectory + f, { concurrency: 1 }))
+        files.map(f => this.transport.fastGet(this.directory + f, outputDirectory + f, { concurrency: 1 }))
       );
     }
     catch (err) {
       console.error(err);
     }
 
-    this.sftp.end();
+    this.transport.end();
 
     return files.map(filename => outputDirectory + filename);
   }

--- a/libs/dtd-source/src/FeedTransport.ts
+++ b/libs/dtd-source/src/FeedTransport.ts
@@ -1,0 +1,16 @@
+import {FileEntry, TransferOptions} from "ssh2";
+
+/**
+ * Where feed files come from.
+ *
+ * SFTP is the only implementation today and the DTD host still serves files
+ * that way, but credential issuance moved from the NRDP to Rail Data
+ * Marketplace in early 2026, and RDM offers an API. This is the seam that lets
+ * a second transport arrive without `DownloadCommand` knowing: it lists and it
+ * fetches, which is all downloading a feed needs.
+ */
+export interface FeedTransport {
+  readdir(path: string): Promise<FileEntry[]>;
+  fastGet(remote: string, local: string, options?: TransferOptions): Promise<void>;
+  end(): void;
+}

--- a/libs/dtd-source/src/PromiseSFTP.ts
+++ b/libs/dtd-source/src/PromiseSFTP.ts
@@ -1,16 +1,63 @@
 import {Client, ClientSFTPCallback, ConnectConfig, FileEntry, SFTPWrapper, TransferOptions} from "ssh2";
 import { promisify } from "util";
+import {FeedCredentials} from "./Credentials";
+import {FeedTransport} from "./FeedTransport";
+
+/**
+ * The DTD host is old and negotiates none of the defaults a current ssh2 offers,
+ * so the acceptable algorithms are named explicitly. Removing any of these
+ * without testing against the real host will fail at the handshake.
+ */
+const ALGORITHMS: ConnectConfig["algorithms"] = {
+  kex: [
+    "diffie-hellman-group1-sha1",
+    "ecdh-sha2-nistp256",
+    "ecdh-sha2-nistp384",
+    "ecdh-sha2-nistp521",
+    "diffie-hellman-group-exchange-sha256",
+    "diffie-hellman-group14-sha1"
+  ],
+  cipher: [
+    "3des-cbc",
+    "aes128-ctr",
+    "aes192-ctr",
+    "aes256-ctr",
+    "aes128-gcm",
+    "aes128-gcm@openssh.com",
+    "aes256-gcm",
+    "aes256-gcm@openssh.com"
+  ],
+  serverHostKey: [
+    "ssh-dss",
+    "ssh-rsa",
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521"
+  ],
+  hmac: [
+    "hmac-sha2-256",
+    "hmac-sha2-512",
+    "hmac-sha1"
+  ]
+} as ConnectConfig["algorithms"];
 
 
 /**
  * Wrapper around the ssh2 client
  */
-export class PromiseSFTP {
+export class PromiseSFTP implements FeedTransport {
 
   constructor(sftp: SFTPWrapper, client: Client) {
     this.readdir = promisify(sftp.readdir.bind(sftp));
     this.fastGet = promisify(sftp.fastGet.bind(sftp));
     this.end = client.end.bind(client);
+  }
+
+  /**
+   * Connect with the credentials the environment supplies.
+   */
+  public static open(credentials: FeedCredentials): Promise<PromiseSFTP> {
+    return PromiseSFTP.connect({...credentials, algorithms: ALGORITHMS});
   }
 
   /**

--- a/libs/dtd-source/src/index.ts
+++ b/libs/dtd-source/src/index.ts
@@ -1,4 +1,7 @@
 export {PromiseSFTP} from "./PromiseSFTP";
+export {DTD_HOST, feedCredentials} from "./Credentials";
+export type {FeedCredentials} from "./Credentials";
+export type {FeedTransport} from "./FeedTransport";
 export {NO_CURSOR} from "./FeedCursor";
 export type {FeedCursor} from "./FeedCursor";
 export {DownloadCommand} from "./DownloadCommand";


### PR DESCRIPTION
**Stacked on #131 → #130 → #128 → #127 → #126 → #125 → #124.**

The last open item in Epic C. C4 (`apps/dtd2postgres`) stays deferred — the plan holds it back deliberately, on the grounds that validating a `Storage` abstraction against a backend that does not exist yet, while moving 3,500 lines, gives two sources of uncertainty and no way to tell which caused a failure.

## What actually changed in the world

The National Rail open data portal at `opendata.nationalrail.co.uk` was retired in early 2026. An account for the Timetable and Fares feeds now comes from a **Rail Data Marketplace** subscription. The SFTP host is unchanged and still serves the files — **only issuance moved**.

That is a documentation problem wearing a code problem's clothes. A missing variable failed at the SSH handshake, with nothing to suggest the portal you were reading about no longer exists.

```
SFTP_USERNAME and SFTP_PASSWORD are needed to download a feed. They come from a Rail Data
Marketplace subscription to the Timetable and Fares feeds - raildata.org.uk - not from the
National Rail open data portal, which was retired in early 2026. SFTP_HOSTNAME overrides
the host, which defaults to dtd.atocrsp.org.
```

`feedCredentials()` resolves the environment in one place; `apps/dtd2mysql/README.md` says the same thing.

## The seam

`FeedTransport` is two methods — list and fetch — which is all downloading a feed needs. `DownloadCommand` depends on that rather than on `PromiseSFTP`, so an RDM API implementation can arrive without touching the command.

`PromiseSFTP` implements it and takes the ssh2 algorithm list with it. That was **30 lines of cipher and key-exchange negotiation sitting in `container.ts`** — a wiring file — where the comment explaining why none of it can be deleted had nowhere sensible to live. It lives next to the client now.

## Not done, on purpose

**No RDM API transport.** Nothing calls that API, the SFTP host serves the files perfectly well, and writing a second implementation against an interface this project has never exercised would be guessing at its shape. The seam is the deliverable; the second implementation is whoever needs it.

## Verification

- 273 tests pass (three new, covering the credential resolution and the error), typecheck clean
- No behaviour change to any command: the same host, the same algorithms, the same environment variables
- `--help` on both CLIs still runs from the repository root