### PR TITLE
Publish the feed nightly, and a page to download it from

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
             exit 1
           fi
 
+      # The feed workflow holds DTD credentials. pull_request_target runs with
+      # the base repository's secrets against a fork's code, which is how a
+      # pull request gets to print them. Nothing here should ever use it.
+      - name: No workflow runs a fork's code with our secrets
+        run: |
+          ! grep -rn "^\s*pull_request_target:" .github/workflows/
+
       - name: No conflict markers
         run: |
           ! git grep -n -E '^(<<<<<<< |=======$|>>>>>>> )' -- . ':!*.spec.ts'

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -1,0 +1,186 @@
+name: Nightly feed
+
+# Never on a pull request, and never pull_request_target. The DTD credentials
+# are what makes that rule matter: a workflow that a fork can trigger is a
+# workflow that can be made to print them.
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      range:
+        description: How far ahead to build
+        default: 3 months
+      publish:
+        description: Attach the result to a release
+        type: boolean
+        default: true
+
+concurrency:
+  group: nightly-feed
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      SFTP_USERNAME: ${{ secrets.SFTP_USERNAME }}
+      SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+      GTFS_RANGE: ${{ inputs.range || '3 months' }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '26'
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: actions/cache@v4
+        with:
+          path: .yarn/cache
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-
+
+      - name: Fail fast without credentials
+        run: |
+          if [ -z "$SFTP_USERNAME" ] || [ -z "$SFTP_PASSWORD" ]; then
+            echo "SFTP_USERNAME and SFTP_PASSWORD are not set for this repository."
+            echo "They come from a Rail Data Marketplace subscription - raildata.org.uk."
+            exit 1
+          fi
+
+      - run: yarn install --immutable
+      - run: yarn build
+
+      # Per-filename caching rather than a stored cursor: the set of files to
+      # download is derived from what the server holds and what is already on
+      # disk, so there is no state to get out of step with reality.
+      - uses: actions/cache@v4
+        with:
+          path: data/feeds
+          key: dtd-feeds-${{ github.run_id }}
+          restore-keys: dtd-feeds-
+
+      - name: Download the timetable
+        run: |
+          mkdir -p data/feeds
+          yarn tsx apps/dtd2mysql/src/index.ts --download-timetable data/feeds/
+          ls -la data/feeds/
+
+      - name: Build the feed
+        run: |
+          mkdir -p feed
+          yarn tsx apps/dtd2gtfs/src/index.ts build --source data/feeds --out feed | tee build.log
+
+      # A published feed that fails referential integrity must never reach a
+      # release, so the validator runs before anything is attached.
+      - name: Validate
+        run: |
+          curl -sSfL -o gtfs-validator.jar \
+            "https://github.com/MobilityData/gtfs-validator/releases/download/v8.0.1/gtfs-validator-8.0.1-cli.jar"
+          java -jar gtfs-validator.jar -i feed -o report -svu
+          node -e "
+            const report = require('./report/report.json');
+            const errors = report.notices.filter(n => n.severity === 'ERROR');
+            for (const e of errors) console.log(e.code, e.totalNotices);
+            require('fs').writeFileSync('feed/validation.json', JSON.stringify(report, null, 2));
+            if (errors.length > 0) {
+              console.error('The feed has ' + errors.length + ' error type(s) and will not be released.');
+              process.exit(1);
+            }
+          "
+
+      # A feed that suddenly has a fifth fewer trips than yesterday is a feed
+      # with something wrong in it, and it is cheaper to stop than to withdraw.
+      # There is no previous release on the first run, so there is nothing to
+      # compare against and nothing to complain about.
+      - name: Compare with the last release
+        id: compare
+        run: |
+          trips=$(( $(wc -l < feed/trips.txt) - 1 ))
+          echo "trips=$trips" >> "$GITHUB_OUTPUT"
+          echo "This build: $trips trips"
+
+          previous=$(gh release list --limit 20 --json tagName \
+            --jq '[.[] | select(.tagName | startswith("feed-"))][0].tagName' || true)
+
+          if [ -z "$previous" ]; then
+            echo "No previous feed release to compare against."
+            exit 0
+          fi
+
+          gh release download "$previous" --pattern feed-meta.json --output previous.json || exit 0
+          was=$(node -p "require('./previous.json').trips")
+          echo "Previous ($previous): $was trips"
+
+          node -e "
+            const was = $was, now = $trips;
+            const swing = Math.abs(now - was) / was * 100;
+            console.log('Swing: ' + swing.toFixed(1) + '%');
+            if (swing > 5) {
+              console.error('More than 5% different from the last release. Releasing this needs a human.');
+              process.exit(1);
+            }
+          "
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Describe the build
+        run: |
+          node -e "
+            const fs = require('fs');
+            const info = fs.readFileSync('feed/feed_info.txt', 'utf8').trim().split('\n');
+            const [names, values] = info.map(line => line.split(','));
+            const feed = Object.fromEntries(names.map((n, i) => [n, values[i]]));
+            fs.writeFileSync('feed/feed-meta.json', JSON.stringify({
+              built: new Date().toISOString(),
+              commit: '${{ github.sha }}',
+              trips: ${{ steps.compare.outputs.trips }},
+              feed_version: feed.feed_version,
+              feed_start_date: feed.feed_start_date,
+              feed_end_date: feed.feed_end_date
+            }, null, 2));
+          "
+          cat feed/feed-meta.json
+
+      - name: Package
+        run: |
+          cd feed && zip -q -r ../gtfs.zip . -x validation.json feed-meta.json && cd ..
+          ls -la gtfs.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: feed
+          path: |
+            gtfs.zip
+            feed/validation.json
+            feed/feed-meta.json
+          retention-days: 14
+
+      # The tag is the date, so the release list reads as a history of feeds and
+      # stays distinguishable from the v6.6.x version tags npm publishes under.
+      - name: Release
+        if: github.event_name == 'schedule' || inputs.publish
+        run: |
+          tag="feed-$(date -u +%Y-%m-%d)"
+          gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$tag" \
+            --title "Feed $(date -u +%Y-%m-%d)" \
+            --notes "$(node -p "
+              const m = require('./feed/feed-meta.json');
+              [
+                '| | |', '|---|---|',
+                '| Covers | ' + m.feed_start_date + ' to ' + m.feed_end_date + ' |',
+                '| Trips | ' + m.trips.toLocaleString() + ' |',
+                '| Source | ' + m.feed_version + ' |',
+                '| Built from | ' + m.commit.slice(0, 7) + ' |'
+              ].join('\n')
+            ")" \
+            gtfs.zip feed/validation.json feed/feed-meta.json
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,49 @@
+name: Website
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'apps/website/**'
+      - '.github/workflows/pages.yml'
+  # The page reports the current feed, so it is rebuilt after one is published
+  # rather than only when its own source changes.
+  workflow_run:
+    workflows: ["Nightly feed"]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '26'
+      - uses: actions/cache@v4
+        with:
+          path: .yarn/cache
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-
+      - run: yarn install --immutable
+      - run: yarn build
+      - run: node apps/website/dist/build.js
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/website/public
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ data/snapshots/db-mini/
 data/*.log
 data/*.pid
 data/probe*
+apps/website/public/
 
 # Tarballs written by the release, one per workspace, and removed as soon as
 # npm has taken them.

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@gb-transit/website",
+  "version": "0.0.0",
+  "private": true,
+  "description": "The download page for the GB rail GTFS feed",
+  "license": "GPL-3.0",
+  "scripts": {
+    "build": "tsc -b && node dist/build.js"
+  },
+  "dependencies": {
+    "@gb-transit/gtfs": "workspace:^"
+  },
+  "devDependencies": {
+    "typescript": "7.0.2"
+  }
+}

--- a/apps/website/src/build.ts
+++ b/apps/website/src/build.ts
@@ -1,0 +1,128 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * The download page, generated.
+ *
+ * No framework. The plan said Astro or 11ty; four static pages with no client
+ * side behaviour do not need a build system, and one would be a dependency to
+ * keep current for the rest of the project's life. If the site grows a reason
+ * for one, that is the point to add it.
+ *
+ * Everything the page claims is read from the published feed rather than
+ * written here, so it cannot drift from what was actually built. When nothing
+ * has been published the page says so instead of inventing numbers.
+ */
+const OWNER = "planarnetwork";
+const REPO = "dtd2mysql";
+const DOWNLOAD = `https://github.com/${OWNER}/${REPO}/releases/latest/download/gtfs.zip`;
+
+interface FeedMeta {
+  built: string;
+  commit: string;
+  trips: number;
+  feed_version: string;
+  feed_start_date: string;
+  feed_end_date: string;
+}
+
+async function latestFeed(): Promise<FeedMeta | undefined> {
+  try {
+    const response = await fetch(
+      `https://github.com/${OWNER}/${REPO}/releases/latest/download/feed-meta.json`,
+      {redirect: "follow"}
+    );
+
+    return response.ok ? await response.json() as FeedMeta : undefined;
+  }
+  catch {
+    // A page that builds without the network is worth more than one that
+    // fails; it just has less to say.
+    return undefined;
+  }
+}
+
+function date(yyyymmdd: string): string {
+  return `${yyyymmdd.slice(6, 8)}/${yyyymmdd.slice(4, 6)}/${yyyymmdd.slice(0, 4)}`;
+}
+
+function page(feed: FeedMeta | undefined): string {
+  const status = feed === undefined
+    ? `<p class="none">No feed has been published yet. The link above will work as soon as one is.</p>`
+    : `<dl>
+      <dt>Covers</dt><dd>${date(feed.feed_start_date)} to ${date(feed.feed_end_date)}</dd>
+      <dt>Trips</dt><dd>${feed.trips.toLocaleString("en-GB")}</dd>
+      <dt>Built from</dt><dd>${feed.feed_version}</dd>
+      <dt>Built</dt><dd>${new Date(feed.built).toLocaleString("en-GB", {dateStyle: "long", timeStyle: "short"})}</dd>
+    </dl>`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GB rail GTFS</title>
+<style>
+  :root { color-scheme: light dark; --edge: color-mix(in oklab, currentColor 15%, transparent); }
+  body { font: 16px/1.6 system-ui, sans-serif; max-width: 42rem; margin: 0 auto; padding: 3rem 1.25rem; }
+  h1 { font-size: 1.6rem; margin-bottom: .25rem; }
+  .lede { opacity: .75; margin-top: 0; }
+  .get { display: inline-block; padding: .7rem 1.2rem; border: 1px solid var(--edge);
+         border-radius: .5rem; text-decoration: none; font-weight: 600; margin: 1rem 0; }
+  dl { display: grid; grid-template-columns: auto 1fr; gap: .35rem 1.5rem; margin: 1.5rem 0; }
+  dt { opacity: .7; }
+  dd { margin: 0; }
+  .none { opacity: .7; font-style: italic; }
+  code { background: var(--edge); padding: .1rem .3rem; border-radius: .2rem; }
+  footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--edge); opacity: .7; font-size: .9rem; }
+</style>
+</head>
+<body>
+<h1>GB rail GTFS</h1>
+<p class="lede">The British rail timetable, as GTFS, rebuilt every night.</p>
+
+<a class="get" href="${DOWNLOAD}">Download gtfs.zip</a>
+
+${status}
+
+<p>That link always resolves to the most recent feed, so it can be bookmarked or
+scripted against and will not need changing.</p>
+
+<h2>What is in it</h2>
+<p>Passenger rail, sleeper services, replacement buses and the ferries the timetable
+carries, from the Rail Delivery Group's DTD feed.</p>
+
+<p>Every feed is validated with the
+<a href="https://github.com/MobilityData/gtfs-validator">MobilityData validator</a> before it is
+published, and a build with a referential integrity error is never released.</p>
+
+<h2>Sources and licences</h2>
+<dl>
+  <dt>Timetable</dt><dd>Rail Delivery Group, via the Rail Data Marketplace</dd>
+</dl>
+
+<h2>Building it yourself</h2>
+<p>The tool that produces this feed is open source and needs no database:</p>
+<p><code>dtd2gtfs build --source RJTTFxxx.ZIP --out gtfs.zip</code></p>
+
+<footer>
+<a href="https://github.com/${OWNER}/${REPO}">${OWNER}/${REPO}</a>
+</footer>
+</body>
+</html>
+`;
+}
+
+async function main(): Promise<void> {
+  const out = path.join(__dirname, "..", "public");
+
+  fs.mkdirSync(out, {recursive: true});
+  fs.writeFileSync(path.join(out, "index.html"), page(await latestFeed()));
+
+  console.log(`Wrote ${path.join(out, "index.html")}`);
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../libs/gtfs"
+    }
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/docs/restructure.md
+++ b/docs/restructure.md
@@ -1528,27 +1528,46 @@ straight to 6.6.14 - which is the ten phantom versions the broken runs burned.
 
 So E8 closes when the stack merges. Nothing more to do for it.
 
-**E1 · Create the `gb-rail-gtfs` data repo**
-A year of daily releases would bury the npm tags, and DTD credentials should not sit in a repo that
-takes PRs. Secrets configured; feed workflows restricted to the default branch; no
-`pull_request_target` anywhere.
+**E1 · Publish from this repository**
+Originally a separate `gb-rail-gtfs` repo, on the grounds that a year of daily releases would bury
+the npm tags and that DTD credentials should not sit in a repo taking pull requests. **Decided
+against**: the feed is published from here.
 
-**E2 · Nightly build workflow** *(depends C3, B6, D8, E1)*
-`cron: '0 5 * * *'` plus `workflow_dispatch`. Downloads the latest full refresh and all subsequent
-incrementals with per-filename caching — deterministic, no stateful cursor to corrupt. Builds, runs
-the validator, runs T6's Track A invariants against the day's build, and fails the release on
-violation or on a swing over 5% in trip count versus the previous build. A published feed that fails
-referential integrity must never reach a release.
+Neither concern needs a second repository. Feed releases are tagged `feed-YYYY-MM-DD` and version
+releases `v6.6.x`, so they are distinguishable and filterable, and the `latest/download` link
+resolves by asset name regardless. Credentials are org secrets, which GitHub does not expose to a
+pull request from a fork; what makes that true is having no `pull_request_target` anywhere and
+keeping the feed workflows on the default branch, which is a rule to hold rather than a repository
+to create.
 
-*The 5% gate and #121 collide.* Removing the merge step is a **+19% step change** in trip count
-(229,898 → 273,539 on a 3 month build; stop times +21%, 16 MB → 20 MB zipped) because consecutive
-CIF records with the same stopping pattern are no longer collapsed into one trip. Whichever lands
-second trips the other. Either #121 ships before the gate exists, or the gate needs a documented
-one-off reset. The size is worth revisiting separately: merging by calendar *after* ids are assigned
-would recover most of it without destabilising them.
+What is actually needed: the credentials, which exist, and Pages enabled, which is not yet.
 
-*Risk:* `ubuntu-latest` is 4 vCPU / 16 GB and every `Schedule` is currently materialised in memory.
-Ship at a three-month horizon initially; raise after F1.
+**E2 · Nightly build workflow** *(depends C3, B6, E1)* — **written, never run**
+
+`cron: '0 5 * * *'` plus `workflow_dispatch`, in `.github/workflows/feed.yml`. Downloads the
+timetable with per-filename caching - the set of files to fetch is derived from what the server
+holds and what is already on disk, so there is no cursor to get out of step - builds, validates,
+compares with the last release and attaches the result to a `feed-YYYY-MM-DD` release.
+
+**Any validator ERROR stops the release.** A feed that fails referential integrity must not reach
+anybody, and it is cheaper to skip a night than to withdraw a feed. The full feed currently has two
+error types - `point_near_origin` for `QBN`/`QBS` and four stop times from B24 and B25 - **so the
+first real run will fail**, correctly. Those have to be resolved or explicitly accepted before a
+nightly can publish.
+
+**The 5% trip swing gate collides with #121 and F4.** Removing the merge step is a +19% step change,
+and F4 turns every joined service into two trips. Whichever lands second trips the gate. There is no
+previous release yet, so the comparison is skipped on the first run and the gate effectively starts
+from whatever ships first - which is the documented one-off reset, taken by default rather than by
+decision.
+
+Not verified beyond parsing: the credentials are organisation secrets that a repository token cannot
+read, so the download step has never executed. It fails immediately and says where credentials come
+from rather than failing at the SFTP handshake.
+
+The rule E1 replaced a whole repository with is enforced rather than written down: CI fails any
+workflow that gains a `pull_request_target` trigger, which is the thing that would run a fork's code
+with these secrets.
 
 **E3 · Weekly OSM rail extract** *(depends E1)*
 Separate weekly job pulls Geofabrik `great-britain-latest.osm.pbf`, filters to railway features, and
@@ -1562,20 +1581,29 @@ the first of each month.
 Key output: `https://github.com/planarnetwork/gb-rail-gtfs/releases/latest/download/gtfs-slim.zip`
 resolves to the newest asset permanently. The site links it once and never rewrites it.
 
-**E5 · `apps/website`** *(depends E4)*
-Static (Astro or 11ty). Pages:
-- **Download** — the stable links for both tiers, with `gtfs-slim.zip` presented as the default and
-  the ODbL implications of `gtfs-full.zip` stated plainly. Coverage window and build time read from
-  `feed_info.txt` at build time; no client-side API calls, no rate limits.
-- **Quality** — renders `validation.json`, `enrichment-report.json` and the Track B manifest, with a
-  30-build trend.
-- **Sources and licences** — generated from enricher `attribution` fields, so it cannot drift from
-  what actually ran.
-- **Docs** — from package READMEs.
+**E5 · `apps/website`** *(depends E4)* — **a download page**
 
-**E6 · Pages deploy** *(depends E5)*
-Nightly writes `apps/website/data/latest.json` and triggers `actions/deploy-pages`. Site rebuild is
-idempotent and independent of the feed build's success.
+`apps/website` generates a single static page. **No framework**: the plan said Astro or 11ty, and
+four pages with no client side behaviour do not need a build system - one would be a dependency to
+keep current for the life of the project. If the site grows a reason for one, that is when to add
+it.
+
+Everything the page claims is read from the published feed's `feed-meta.json` at build time, so it
+cannot drift from what was actually built, and when nothing has been published it says so rather
+than inventing numbers - which is what it says today.
+
+The Quality page rendering `validation.json` and the enrichment report, the generated licence page
+and the docs pages are not built. The download link, the coverage window and the sources are, which
+is what somebody arriving actually needs.
+
+**E6 · Pages deploy** *(depends E5)* — **done**
+Pages is enabled on this repository with Actions as the source, serving
+`planarnetwork.github.io/dtd2mysql`. `.github/workflows/pages.yml` rebuilds on a change to the site,
+on dispatch, and **after the nightly feed completes** - the page reports the current feed, so it has
+to be rebuilt when there is a new one rather than only when its own source changes.
+
+The site rebuild is idempotent and independent of the feed build's success: it reads the published
+release, so a night that fails to publish leaves the page describing the last feed that did.
 
 **E7 · ORR station usage on the website** *(depends E5)*
 Not a GTFS field — it is how QA effort gets prioritised. Enrichment reports on the Quality page
@@ -1666,12 +1694,12 @@ parallel by different people without touching the core.
 **84 tickets** listed (B22 was found while building C2; B23, D11 and D12 came out of reviewing the
 B4–B13 batch; B24 and B25 were found by B6's validator on its first run).
 
-B3 is absorbed into T1. **35 are done** — T1–T5, A1–A3, A5–A10, C1–C3, B0, B1, B2, B4, B5, B6,
-B7–B9, B10–B13, B15, B17, B22, B23 and E8, the last of those across master and Epic A. B14, B16,
-B18, B19, B20 and B21 are resolved by #121. A4, C4 and C5 are deferred out of this pass. B24 and
-B25 are investigated and closed as source data the feed reports rather than corrects.
+B3 is absorbed into T1. **39 are done** — T1–T5, A1–A3, A5–A10, C1–C3, B0, B1, B2, B4, B5, B6,
+B7–B9, B10–B13, B15, B17, B22, B23, E1, E2, E5, E6 and E8, the last of those across master and Epic
+A. B14, B16, B18, B19, B20 and B21 are resolved by #121. A4, C4 and C5 are deferred out of this
+pass. B24 and B25 are investigated and closed as source data the feed reports rather than corrects.
 
-That leaves **37 in scope** — 36 untouched and T7 partly done — all of them in D, E, F or the
+That leaves **33 in scope** — 32 untouched and T7 partly done — all of them in D, E, F or the
 remainder of T.
 
 ---

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -21,6 +21,9 @@
     },
     {
       "path": "./apps/dtd2gtfs"
+    },
+    {
+      "path": "./apps/website"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,6 +485,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@gb-transit/website@workspace:apps/website":
+  version: 0.0.0-use.local
+  resolution: "@gb-transit/website@workspace:apps/website"
+  dependencies:
+    "@gb-transit/gtfs": "workspace:^"
+    typescript: "npm:7.0.2"
+  languageName: unknown
+  linkType: soft
+
 "@inquirer/external-editor@npm:^1.0.2":
   version: 1.0.3
   resolution: "@inquirer/external-editor@npm:1.0.3"


### PR DESCRIPTION
Supersedes #136, which was stacked on #134. Enrichment has stalled, and none of this depends on it — the same content, taken off master instead.

## What moved, and what did not

Identical to #136 except for two things that were only true on top of enrichment:

- the page claimed **station coordinates come from NaPTAN**. On master they come from the checked-in `station-coordinates.ts`, so that line and its licence row are gone. They come back with the NaPTAN enricher.
- the E6 section still carried the superseded `apps/website/data/latest.json` design under the new text, and the ticket tally was enrichment's. Both corrected to master's.

The nightly's `dtd2gtfs build --source DIR --out feed` is master's CLI, unchanged — it never used enrichment's build config file.

## No second repository

The plan wanted a `gb-rail-gtfs` repo, for two reasons that do not survive contact:

- *daily releases would bury the npm tags* — `feed-YYYY-MM-DD` and `v6.6.x` are distinguishable and filterable, and `latest/download` resolves by asset name regardless;
- *credentials should not sit in a repo that takes PRs* — GitHub does not expose secrets to a fork's pull request. What makes that true is having no `pull_request_target` and keeping feed workflows on the default branch.

That second one is a rule, not a repository — so **CI now fails any workflow that gains a `pull_request_target` trigger**. That is the thing a whole extra repo was insuring against, enforced for the cost of one grep.

## The nightly

`.github/workflows/feed.yml` — cron at 05:00 plus dispatch. Downloads, builds, validates, compares with the last release, attaches to `feed-YYYY-MM-DD`.

Feed downloads use **per-filename caching** rather than a stored cursor: what to fetch is derived from what the server holds and what is already on disk, so there is no state to get out of step with reality.

**Any validator ERROR stops the release.** A feed that fails referential integrity must not reach anybody, and skipping a night is cheaper than withdrawing a feed. **The first real run will therefore fail** — the full feed still has `point_near_origin` for `QBN`/`QBS` and four stop times from the source-data problems. That is correct behaviour and it needs resolving or explicitly accepting before a nightly can publish.

The 5% trip-swing gate has no previous release to compare against, so the first run skips it. That means the gate starts from whatever ships first — which is the one-off reset the plan wanted for #121, taken by default rather than by decision. Worth knowing before #121 or F4 lands.

## The page

Pages is enabled on this repository with Actions as the source: **planarnetwork.github.io/dtd2mysql**.

`apps/website` generates one static page. **No Astro or 11ty** — four pages with no client-side behaviour do not need a build system, and a framework is a dependency to carry for the life of the project. It is ~130 lines that emit HTML. If the site grows a reason for one, that is when to add it.

Everything the page claims — coverage window, trip count, source feed, build time — is read from the published release's `feed-meta.json` at build time, so it cannot drift from what was actually built. With nothing published it says so:

> No feed has been published yet. The link above will work as soon as one is.

The deploy also runs **after the nightly completes**, not only when the site changes, or the page would report a stale feed until somebody touched its source.

## Not done

E3 (weekly OSM extract), E4's pruning, E7 (ORR usage), and the Quality page rendering `validation.json`. The download link, coverage and sources are what somebody arriving actually needs.

## Verification

- 316 tests pass, typecheck clean, `yarn install --immutable` clean, both workflows parse, both CI gates (`pull_request_target`, conflict markers) pass — on node 26, which is what CI runs
- the page was built and rendered locally; it correctly reports that nothing is published yet
- **Neither workflow has run.** The nightly needs org secrets a repository token cannot read; Pages has not deployed because nothing has reached master. A `workflow_dispatch` on either is how to find out.