### PR TITLE
Make the nightly feed run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           [ -n "$base" ] || exit 0
           git fetch -q --depth=1 origin "$base" 2>/dev/null || true
           changed=$(git diff --name-only "$base"...HEAD -- \
-            'apps/*/fixtures/*/golden/**' 'type-surface.json' || true)
+            'apps/*/fixtures/*/golden/**' 'type-surface.json' 'validator-baseline.json' || true)
           [ -n "$changed" ] || exit 0
           echo "Baselines changed:"; echo "$changed"
           if ! git diff --name-only "$base"...HEAD -- 'apps/*/fixtures/BASELINE.md' | grep -q .; then

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -63,9 +63,15 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
 
-      # Per-filename caching rather than a stored cursor: the set of files to
-      # download is derived from what the server holds and what is already on
-      # disk, so there is no state to get out of step with reality.
+      # There is no stored cursor: with no database to import into, the download
+      # takes the most recent full refresh and the incrementals after it every
+      # time, so there is no state to get out of step with reality.
+      #
+      # The cache therefore saves nothing today - the download overwrites what
+      # it restores. It is here because the alternative to a cursor is deriving
+      # the set to fetch from what is already on disk, and that needs the disk
+      # to persist. Until a cursor reads this directory, it is carrying a cost
+      # for a later benefit.
       - uses: actions/cache@v4
         with:
           path: data/feeds
@@ -84,22 +90,15 @@ jobs:
           yarn tsx apps/dtd2gtfs/src/index.ts build --source data/feeds --out feed | tee build.log
 
       # A published feed that fails referential integrity must never reach a
-      # release, so the validator runs before anything is attached.
+      # release, so the validator runs before anything is attached. What counts
+      # as a failure is validator-baseline.json: an unlisted error, or more of
+      # a listed one than it accepts.
       - name: Validate
         run: |
           curl -sSfL -o gtfs-validator.jar \
             "https://github.com/MobilityData/gtfs-validator/releases/download/v8.0.1/gtfs-validator-8.0.1-cli.jar"
           java -jar gtfs-validator.jar -i feed -o report -svu
-          node -e "
-            const report = require('./report/report.json');
-            const errors = report.notices.filter(n => n.severity === 'ERROR');
-            for (const e of errors) console.log(e.code, e.totalNotices);
-            require('fs').writeFileSync('feed/validation.json', JSON.stringify(report, null, 2));
-            if (errors.length > 0) {
-              console.error('The feed has ' + errors.length + ' error type(s) and will not be released.');
-              process.exit(1);
-            }
-          "
+          node scripts/check-validation.mjs
 
       # A feed that suddenly has a fifth fewer trips than yesterday is a feed
       # with something wrong in it, and it is cheaper to stop than to withdraw.

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -27,9 +27,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # The secrets are named for the feed, the variables for the protocol it
+    # arrives over: dtd2mysql reads SFTP_*, so the names cannot be made to
+    # match on either side and the mapping belongs here.
     env:
-      SFTP_USERNAME: ${{ secrets.SFTP_USERNAME }}
-      SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+      SFTP_HOSTNAME: ${{ secrets.DTD_HOSTNAME }}
+      SFTP_USERNAME: ${{ secrets.DTD_USERNAME }}
+      SFTP_PASSWORD: ${{ secrets.DTD_PASSWORD }}
       GTFS_RANGE: ${{ inputs.range || '3 months' }}
     steps:
       - uses: actions/checkout@v5
@@ -48,8 +52,10 @@ jobs:
 
       - name: Fail fast without credentials
         run: |
+          # DTD_HOSTNAME is not required: dtd2mysql defaults it to
+          # dtd.atocrsp.org when it is empty.
           if [ -z "$SFTP_USERNAME" ] || [ -z "$SFTP_PASSWORD" ]; then
-            echo "SFTP_USERNAME and SFTP_PASSWORD are not set for this repository."
+            echo "The DTD_USERNAME and DTD_PASSWORD secrets are not set for this repository."
             echo "They come from a Rail Data Marketplace subscription - raildata.org.uk."
             exit 1
           fi

--- a/apps/dtd2mysql/src/container.spec.ts
+++ b/apps/dtd2mysql/src/container.spec.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect} from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import {commands} from "./container";
+import {commands, feedCursor} from "./container";
 
 /**
  * The CLI's flags, held to the README.
@@ -45,6 +45,34 @@ describe("the CLI flags", () => {
       .map(([flag]) => flag);
 
     expect(empty).to.deep.equal([]);
+  });
+
+});
+
+/**
+ * Downloading imports nothing, so it has nothing to be behind and needs no
+ * database. The log table only says anything where there is one to import into.
+ *
+ * The nightly feed build is the caller with no database, and it failed here:
+ * the cursor was constructed eagerly, so an unset DATABASE_NAME threw before
+ * the code that treats a missing log as "take the latest full refresh" could
+ * run. Only the pool construction is asserted - reaching for a connection is
+ * the failure, whatever a query would have gone on to do.
+ */
+describe("the feed cursor", () => {
+
+  it("needs no database, because downloading does not import", async () => {
+    const before = process.env.DATABASE_NAME;
+    delete process.env.DATABASE_NAME;
+
+    try {
+      await expect(feedCursor().getLastProcessedFile()).resolves.to.equal(undefined);
+    }
+    finally {
+      if (before !== undefined) {
+        process.env.DATABASE_NAME = before;
+      }
+    }
   });
 
 });

--- a/apps/dtd2mysql/src/container.ts
+++ b/apps/dtd2mysql/src/container.ts
@@ -10,8 +10,10 @@ import {
   DownloadAndProcessCommand,
   DownloadCommand,
   DownloadFileCommand,
+  NO_CURSOR,
   PromiseSFTP
 } from "@gb-transit/dtd-source";
+import type {FeedCursor} from "@gb-transit/dtd-source";
 import {CLICommand} from "./cli/CLICommand";
 import {CleanFaresCommand} from "./cli/CleanFaresCommand";
 import {GTFSImportCommand} from "./cli/GTFSImportCommand";
@@ -168,9 +170,22 @@ const getSFTP = once((_: null): Promise<PromiseSFTP> =>
   })
 );
 
+/**
+ * The log table records what ImportFeedCommand imported, so it only says
+ * anything where there is a database to import into. Downloading does not need
+ * one - `--download-timetable` writes files and imports nothing - so without a
+ * database it takes the latest full refresh, which is what NO_CURSOR means.
+ *
+ * The cursor already treats a missing log as "start from the most recent full
+ * refresh"; constructing it eagerly is what turned that into a failure instead.
+ */
+export function feedCursor(): FeedCursor {
+  return process.env.DATABASE_NAME ? new LogTableFeedCursor(databaseConnection()) : NO_CURSOR;
+}
+
 const getDownloadCommand = once(async (directory: string) =>
   new DownloadCommand(
-    new LogTableFeedCursor(databaseConnection()),
+    feedCursor(),
     await getSFTP(null),
     directory
   )

--- a/docs/restructure.md
+++ b/docs/restructure.md
@@ -727,16 +727,25 @@ code rather than of the date it runs.
 now the tube links are in there.
 
 **The full feed does not, and the job does not cover it** - it needs a 70 MB source and does not
-belong in a PR check. Running it by hand against `RJTTF918` found three errors:
+belong in a PR check. Running it by hand against `RJTTF918` found three errors; E2's nightly now
+runs it on every build, and the first one to get that far reported two:
 
 | | | |
 |---|---:|---|
-| `foreign_key_violation` | 36 | the `QHA`/`ZUX` stop times - B15 |
+| `foreign_key_violation` | 0 | the `QHA`/`ZUX` stop times - **cleared by B15** |
 | `point_near_origin` | 2 | `QBN`/`QBS` at 0,0 - B10 put them there deliberately |
-| `stop_time_with_arrival_before_previous_departure_time` | 4 | **new, see B24 and B25** |
+| `stop_time_with_arrival_before_previous_departure_time` | 4 | see B24 and B25 |
 
-That gap is real: a green PR check does not mean the published feed validates. Whoever does E2's
-nightly should run the validator there.
+That gap is real: a green PR check does not mean the published feed validates. E2's nightly runs the
+validator there, which is what closes it.
+
+**The two that remain are decisions, so "any ERROR blocks" would never pass.** `validator-baseline.json`
+names them and how many of each, and `scripts/check-validation.mjs` holds the build to it: an error
+that is not listed fails, and so does a listed one that grew, because an accepted error is a known
+quantity rather than a licence for more of the same. Fewer than the baseline allows is reported and
+passes - `point_near_origin` goes to 0 when D3 or D7 gives `QBN`/`QBS` coordinates, and that is the
+moment to lower it. Changing the file is covered by the same CI gate as `type-surface.json` and the
+goldens, so loosening it has to be explained.
 
 **B24 · A joined trip visits a station twice with time going backwards** — *investigated; the source is inconsistent, and the feed reports it*
 
@@ -1540,20 +1549,24 @@ pull request from a fork; what makes that true is having no `pull_request_target
 keeping the feed workflows on the default branch, which is a rule to hold rather than a repository
 to create.
 
-What is actually needed: the credentials, which exist, and Pages enabled, which is not yet.
+What is actually needed: the credentials, which exist, and Pages enabled, which it now is.
 
-**E2 · Nightly build workflow** *(depends C3, B6, E1)* — **written, never run**
+**E2 · Nightly build workflow** *(depends C3, B6, E1)* — **run, through to a validated feed**
 
 `cron: '0 5 * * *'` plus `workflow_dispatch`, in `.github/workflows/feed.yml`. Downloads the
-timetable with per-filename caching - the set of files to fetch is derived from what the server
-holds and what is already on disk, so there is no cursor to get out of step - builds, validates,
-compares with the last release and attaches the result to a `feed-YYYY-MM-DD` release.
+timetable, builds, validates, compares with the last release and attaches the result to a
+`feed-YYYY-MM-DD` release.
 
-**Any validator ERROR stops the release.** A feed that fails referential integrity must not reach
-anybody, and it is cheaper to skip a night than to withdraw a feed. The full feed currently has two
-error types - `point_near_origin` for `QBN`/`QBS` and four stop times from B24 and B25 - **so the
-first real run will fail**, correctly. Those have to be resolved or explicitly accepted before a
-nightly can publish.
+Downloading needs no database. It used to: `DownloadCommand` takes a `FeedCursor`, the only one
+wired up read the `log` table, and constructing it eagerly meant an unset `DATABASE_NAME` threw
+before anything ran. But downloading imports nothing, so there is nothing to be behind -
+`--download-timetable` now uses `NO_CURSOR`, which the library already had for exactly this, and
+takes the latest full refresh.
+
+**An unaccepted validator ERROR stops the release.** A feed that fails referential integrity must
+not reach anybody, and it is cheaper to skip a night than to withdraw a feed. What counts as
+accepted is `validator-baseline.json` - see the B6 section above for why a blanket rule could not
+work and what the file holds.
 
 **The 5% trip swing gate collides with #121 and F4.** Removing the merge step is a +19% step change,
 and F4 turns every joined service into two trips. Whichever lands second trips the gate. There is no
@@ -1561,9 +1574,10 @@ previous release yet, so the comparison is skipped on the first run and the gate
 from whatever ships first - which is the documented one-off reset, taken by default rather than by
 decision.
 
-Not verified beyond parsing: the credentials are organisation secrets that a repository token cannot
-read, so the download step has never executed. It fails immediately and says where credentials come
-from rather than failing at the SFTP handshake.
+Verified by running it: download, build and validate all execute against the real feed. The
+credentials are held as `DTD_HOSTNAME`, `DTD_USERNAME` and `DTD_PASSWORD` and mapped to the
+`SFTP_*` variables dtd2mysql reads, which is where the first run stopped - the workflow asked for
+secrets by the variable names rather than the secret names.
 
 The rule E1 replaced a whole repository with is enforced rather than written down: CI fails any
 workflow that gains a `pull_request_target` trigger, which is the thing that would run a fork's code

--- a/scripts/check-validation.mjs
+++ b/scripts/check-validation.mjs
@@ -1,0 +1,52 @@
+import * as fs from "node:fs";
+
+/**
+ * Hold the validator report to validator-baseline.json.
+ *
+ * "Any ERROR stops the release" cannot be the rule, because two of them are
+ * decisions: B10 publishes an unlocated stop at 0,0 so that a validator flags
+ * it, and B24/B25 are closed as source data the feed reports rather than
+ * corrects. A gate that can never pass is a gate somebody turns off.
+ *
+ * So the baseline names the errors that are accepted and how many of each. An
+ * unlisted code fails, and so does a listed one that grew - an accepted error
+ * is a known quantity, not a licence for more of the same. Fewer than the
+ * baseline allows is reported rather than accepted silently, because that is
+ * the moment to tighten it.
+ */
+const report = JSON.parse(fs.readFileSync("report/report.json", "utf8"));
+const baseline = JSON.parse(fs.readFileSync("validator-baseline.json", "utf8"));
+
+const errors = report.notices.filter(notice => notice.severity === "ERROR");
+const counted = new Map(errors.map(error => [error.code, error.totalNotices]));
+
+const unlisted = [...counted].filter(([code]) => !baseline.hasOwnProperty(code));
+const grown = [...counted].filter(([code, count]) => baseline[code] && count > baseline[code].max);
+const shrunk = Object.entries(baseline).filter(([code, {max}]) => (counted.get(code) ?? 0) < max);
+
+for (const [code, count] of counted) {
+  console.log(`${code} ${count}${baseline[code] ? ` (baseline ${baseline[code].max})` : ""}`);
+}
+
+for (const [code, count] of unlisted) {
+  console.error(`\n${code}: ${count}, and validator-baseline.json does not accept it.`);
+  console.error("Fix it, or add it to the baseline with the reason it is acceptable.");
+}
+
+for (const [code, count] of grown) {
+  console.error(`\n${code}: ${count}, but the baseline allows ${baseline[code].max}.`);
+  console.error(`Accepted because: ${baseline[code].why}`);
+  console.error("More of an accepted error is not accepted. Something changed.");
+}
+
+for (const [code, {max}] of shrunk) {
+  console.log(`\n${code}: ${counted.get(code) ?? 0}, below the baseline of ${max}.`);
+  console.log("Lower validator-baseline.json to keep it from coming back.");
+}
+
+fs.writeFileSync("feed/validation.json", JSON.stringify(report, null, 2));
+
+if (unlisted.length > 0 || grown.length > 0) {
+  console.error("\nThe feed will not be released.");
+  process.exit(1);
+}

--- a/validator-baseline.json
+++ b/validator-baseline.json
@@ -1,0 +1,10 @@
+{
+  "point_near_origin": {
+    "max": 2,
+    "why": "B10: a stop with no coordinate that something references is published at 0,0 and named in a warning, rather than at a plausible centroid that would hide it. QBN/QBS are the two. Goes to 0 when D3 or D7 gives them coordinates."
+  },
+  "stop_time_with_arrival_before_previous_departure_time": {
+    "max": 4,
+    "why": "B24 and B25: G38297/G38968, a JJ join at Swansea, where the source disagrees with itself on three of the six dates the association covers. Investigated and closed as source data the feed reports rather than corrects."
+  }
+}


### PR DESCRIPTION
#139 shipped the pipeline unexecuted. Running it found three things, each fixed here. **The nightly now goes green end to end** — [run 32870167752](https://github.com/planarnetwork/dtd2mysql/actions/runs/32870167752) — producing a validated 294,068-trip feed covering 25/08/2026 to 25/11/2026 from `RJTTC938.ZIP`.

Every run below was dispatched with `publish: false`, so nothing has been released yet.

## 1. The secrets have different names

The workflow asked for `secrets.SFTP_USERNAME` and `secrets.SFTP_PASSWORD`. The repository holds `DTD_HOSTNAME`, `DTD_USERNAME` and `DTD_PASSWORD`, so both resolved empty and the run stopped at the credentials guard — correctly, but for a reason that was the workflow's own.

`dtd2mysql` reads `SFTP_HOSTNAME`/`SFTP_USERNAME`/`SFTP_PASSWORD` from the environment, so the variable names stay and the mapping happens where the secrets are read. `DTD_HOSTNAME` is wired up too rather than leaning on the `dtd.atocrsp.org` default.

## 2. Downloading a feed needed a database

`--download-timetable` writes files and imports nothing, but it threw `Please set the DATABASE_NAME environment variable` before it ever contacted the server.

`DownloadCommand` takes a `FeedCursor` to answer "what was the last file *processed*" — and processed means imported, recorded in the `log` table by `ImportFeedCommand`. Download and import are designed as halves of `--get-timetable`, so download asks the import side where it got to. That is fine when there is an import. The nightly imports nothing, so nothing ever writes the log for it to read.

`FeedCursor` already said as much:

> the storage apps back it with their log table, and a build with no database uses `NO_CURSOR` and takes the latest full refresh every time

`NO_CURSOR` existed for exactly this and the container never used it. What made it unreachable was constructing the cursor eagerly, so an unset `DATABASE_NAME` threw at pool construction before `LogTableFeedCursor`'s own "a missing log means start from the most recent full refresh" could run.

## 3. The validator gate could never pass

With the download fixed the run reached the validator and reported:

```
point_near_origin 2
stop_time_with_arrival_before_previous_departure_time 4
```

Both are decisions, not defects. B10 publishes an unlocated-but-referenced stop at 0,0 *so that* a validator flags it — `QBN`/`QBS` are the two. B24 and B25 are closed as source data the feed reports rather than corrects. So "any ERROR stops the release" could never pass, and the fix for `QBN`/`QBS` is a coordinate override from D3/D7, which is in the deferred enrichment work.

A gate that cannot pass is a gate somebody turns off. `validator-baseline.json` names what is accepted and how many of each, and `scripts/check-validation.mjs` holds the build to it:

- an error that is **not listed** fails
- a listed one that **grew** fails — an accepted error is a known quantity, not a licence for more of the same
- **fewer** than the baseline passes and says to tighten it, which is what happens when D3 gives `QBN`/`QBS` coordinates

Changing the file falls under the CI gate that already requires `type-surface.json` and the goldens to be explained. All five branches were tested against a fixture.

**B15 had already cleared the 36 `foreign_key_violation`s** the notes still listed, so that table is corrected.

## Notes corrected

E2 claimed "written, never run" and per-filename caching — the latter was never true, and with `NO_CURSOR` the cache saves nothing today because the download overwrites what it restores. The comment now says that rather than claiming otherwise; the step is kept because deriving the fetch set from disk is what a cursor would need. E1's "Pages enabled, which is not yet" is also out of date: it is enabled and serving.

## Worth knowing before merging

The 5% trip-swing gate has nothing to compare against, so it starts from whatever ships first. This build is 294,068 trips. #121 and F4 both move that number, and whichever lands second trips the gate.