### PR TITLE
Keep the feed releases worth keeping

### DIFF
--- a/.changeset/prune-releases.md
+++ b/.changeset/prune-releases.md
@@ -1,0 +1,25 @@
+---
+"dtd2mysql": patch
+---
+
+Keep the feed releases worth keeping.
+
+A release a day, each carrying a 20 MB zip, accumulates forever. The last month
+is what anybody fetches; past that what is wanted is the ability to say what the
+feed looked like in April, and one release a month answers that as well as
+thirty do. The nightly now keeps the last 30 dailies plus the earliest release
+of each month.
+
+The earliest of the month rather than whichever is dated the 1st, so a night
+that failed to publish does not cost the whole month its record.
+
+The selection is a pure function with tests. A rule that deletes published
+artifacts should not be discoverable only by watching it run, and it considers
+`feed-` tags alone: the npm version tags share the release list, and a pruner
+that could reach them is one bad regular expression from deleting a release of
+the software.
+
+`provenance.json` is attached to the release too, alongside the validation and
+enrichment reports. All four describe the feed rather than being part of it, so
+they are assets rather than zip contents - somebody unzipping a GTFS feed should
+get GTFS.

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Package
         run: |
-          cd feed && zip -q -r ../gtfs.zip . -x validation.json feed-meta.json enrichment-report.json && cd ..
+          cd feed && zip -q -r ../gtfs.zip . -x validation.json feed-meta.json enrichment-report.json provenance.json && cd ..
           ls -la gtfs.zip
 
       - uses: actions/upload-artifact@v4
@@ -175,6 +175,7 @@ jobs:
             feed/validation.json
             feed/feed-meta.json
             feed/enrichment-report.json
+            feed/provenance.json
           retention-days: 14
 
       # The tag is the date, so the release list reads as a history of feeds and
@@ -196,6 +197,19 @@ jobs:
                 '| Built from | ' + m.commit.slice(0, 7) + ' |'
               ].join('\n')
             ")" \
-            gtfs.zip feed/validation.json feed/feed-meta.json feed/enrichment-report.json
+            gtfs.zip feed/validation.json feed/feed-meta.json feed/enrichment-report.json \
+            $([ -f feed/provenance.json ] && echo feed/provenance.json)
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # A release a day, each carrying a 20 MB zip, accumulates forever. The
+      # last month is what anybody fetches; past that what is wanted is the
+      # ability to say what the feed looked like in April, and one release a
+      # month answers that as well as thirty do.
+      #
+      # Runs after the release, so a night that fails to publish prunes nothing.
+      - name: Prune old feeds
+        if: github.event_name == 'schedule' || inputs.publish
+        run: node scripts/prune-releases.mjs
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/restructure.md
+++ b/docs/restructure.md
@@ -1730,13 +1730,25 @@ with these secrets.
 Separate weekly job pulls Geofabrik `great-britain-latest.osm.pbf`, filters to railway features, and
 publishes a small extract as a release asset. The nightly consumes that, never the 1.5 GB source.
 
-**E4 · Release and prune** *(depends E2)*
-Release tagged `feed-YYYY-MM-DD` carrying `gtfs-slim.zip`, `gtfs-full.zip`, `provenance.json`,
-`enrichment-report.json`, `validation.json`, `feed-meta.json`. Prune keeps the last 30 dailies plus
-the first of each month.
+**E4 · Release and prune** *(depends E2)* — **done**
 
-Key output: `https://github.com/planarnetwork/gb-rail-gtfs/releases/latest/download/gtfs-slim.zip`
-resolves to the newest asset permanently. The site links it once and never rewrites it.
+Release tagged `feed-YYYY-MM-DD` carrying `gtfs.zip`, `provenance.json`, `enrichment-report.json`,
+`validation.json` and `feed-meta.json`. Not `gtfs-slim.zip` / `gtfs-full.zip`: the tiering is
+deferred with the rest of D8 until there is a share-alike source to keep out of a permissive build.
+
+The four JSON files are release assets rather than zip contents, because they describe the feed
+rather than being part of it and a GTFS consumer unzipping the feed should get GTFS.
+`provenance.json` is attached only when an enricher ran, since that is when it exists.
+
+Key output: `https://github.com/planarnetwork/dtd2mysql/releases/latest/download/gtfs.zip` resolves
+to the newest asset permanently. The site links it once and never rewrites it.
+
+**Pruning keeps the last 30 dailies plus the earliest release of each month** - the earliest rather
+than whichever is dated the 1st, so a night that failed to publish does not cost the whole month its
+record. The selection is a pure function with tests, because a rule that deletes published artifacts
+should not be discoverable only by watching it run, and it considers `feed-` tags only: the npm
+version tags share the release list, and a pruner that could reach them is one bad regular
+expression from deleting a release of the software.
 
 **E5 · `apps/website`** *(depends E4)* — **a download page**
 
@@ -1864,13 +1876,13 @@ parallel by different people without touching the core.
 B4–B13 batch; B24 and B25 were found by B6's validator on its first run; D13 was found by building
 D12, which did not fit the seam it was said to depend on).
 
-B3 is absorbed into T1. **52 are done** — T1–T5, T6b, T8–T13, A1–A3, A5–A10, C1–C3, B0, B1, B2, B4,
-B5, B6, B7–B9, B10–B13, B15, B17, B22, B23, D1, D2, D3, D8, D12, D13, E1, E2, E5, E6 and E8, the last of
+B3 is absorbed into T1. **53 are done** — T1–T5, T6b, T8–T13, A1–A3, A5–A10, C1–C3, B0, B1, B2, B4,
+B5, B6, B7–B9, B10–B13, B15, B17, B22, B23, D1, D2, D3, D8, D12, D13, E1, E2, E4, E5, E6 and E8, the last of
 those across master and Epic A. B14, B16, B18, B19, B20 and B21 are resolved by #121. A4, C4 and C5
 are deferred out of this pass. B24, B25 and **D4** are investigated and closed as data the feed
 already carries or already reports.
 
-That leaves **20 in scope** — 19 untouched and T7 partly done — all of them in D, E, F or the
+That leaves **19 in scope** — 18 untouched and T7 partly done — all of them in D, E, F or the
 remainder of T.
 
 ---

--- a/scripts/prune-releases.mjs
+++ b/scripts/prune-releases.mjs
@@ -1,0 +1,83 @@
+import {execFileSync} from "node:child_process";
+
+/**
+ * Keep the feed releases worth keeping, and say which.
+ *
+ * A daily feed accumulates a release a day forever, each carrying a 20 MB zip.
+ * The last month is what anybody actually fetches; beyond that what is wanted is
+ * the ability to say what the feed looked like in April, which one release a
+ * month answers as well as thirty do.
+ *
+ * **Only `feed-` tags are considered at all.** The version tags npm publishes
+ * under live in the same list, and a pruner that could reach them is one bad
+ * regular expression away from deleting a release of the software.
+ */
+const KEEP_RECENT = 30;
+const FEED_TAG = /^feed-(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Split feed tags into the ones to keep and the ones to delete.
+ *
+ * Pure, and exported, because the alternative is finding out what it decided by
+ * watching it delete things.
+ */
+export function partition(tags, keepRecent = KEEP_RECENT) {
+  const feeds = tags
+    .filter(tag => FEED_TAG.test(tag))
+    // Lexicographic is chronological for YYYY-MM-DD, newest first.
+    .sort()
+    .reverse();
+
+  const keep = new Set(feeds.slice(0, keepRecent));
+
+  // The earliest release of each month, rather than whichever is dated the 1st:
+  // a night that failed to publish must not cost the whole month its record.
+  const earliest = new Map();
+
+  for (const tag of feeds) {
+    const month = tag.slice(0, "feed-YYYY-MM".length);
+
+    if (!earliest.has(month) || tag < earliest.get(month)) {
+      earliest.set(month, tag);
+    }
+  }
+
+  for (const tag of earliest.values()) {
+    keep.add(tag);
+  }
+
+  return {
+    keep: feeds.filter(tag => keep.has(tag)),
+    remove: feeds.filter(tag => !keep.has(tag))
+  };
+}
+
+function releases() {
+  const json = execFileSync("gh", [
+    "release", "list", "--limit", "1000", "--json", "tagName"
+  ], {encoding: "utf8"});
+
+  return JSON.parse(json).map(release => release.tagName);
+}
+
+function main() {
+  const tags = releases();
+  const {keep, remove} = partition(tags);
+
+  console.log(`${tags.length} releases, ${keep.length} feed releases kept, ${remove.length} to remove`);
+
+  if (remove.length === 0) {
+    return;
+  }
+
+  for (const tag of remove) {
+    console.log(`Removing ${tag}`);
+    execFileSync("gh", ["release", "delete", tag, "--yes", "--cleanup-tag"], {stdio: "inherit"});
+  }
+}
+
+// Only when run. Importing this to test what it would delete should not delete
+// anything.
+if (process.argv[1]?.endsWith("prune-releases.mjs")) {
+  main();
+}

--- a/scripts/prune-releases.spec.mjs
+++ b/scripts/prune-releases.spec.mjs
@@ -1,0 +1,100 @@
+import {describe, it, expect} from "vitest";
+import {partition} from "./prune-releases.mjs";
+
+const feeds = (...dates) => dates.map(date => `feed-${date}`);
+
+/**
+ * A year of dailies, so the monthly keeps can be seen against a real shape.
+ */
+function everyDay(from, days) {
+  const start = new Date(`${from}T00:00:00Z`);
+
+  return Array.from({length: days}, (_, i) => {
+    const day = new Date(start.getTime() + i * 86400000);
+
+    return `feed-${day.toISOString().slice(0, 10)}`;
+  });
+}
+
+describe("partition", () => {
+
+  it("keeps everything while there is little", () => {
+    const {keep, remove} = partition(feeds("2026-08-25", "2026-08-26"));
+
+    expect(keep).to.have.length(2);
+    expect(remove).to.deep.equal([]);
+  });
+
+  it("keeps the most recent 30", () => {
+    const {keep} = partition(everyDay("2026-06-01", 120));
+
+    for (const tag of everyDay("2026-09-", 0)) {
+      expect(keep).to.contain(tag);
+    }
+
+    expect(keep.slice(0, 30)).to.deep.equal(everyDay("2026-08-30", 30).reverse());
+  });
+
+  // A month's worth of dailies is not what anybody fetches, but being able to
+  // say what the feed looked like in June is worth one release.
+  it("keeps the earliest release of every month beyond the recent window", () => {
+    const {keep} = partition(everyDay("2026-06-01", 120));
+
+    expect(keep).to.contain("feed-2026-06-01");
+    expect(keep).to.contain("feed-2026-07-01");
+  });
+
+  // A night that failed to publish must not cost the whole month its record, so
+  // it is the earliest release of the month rather than the one dated the 1st.
+  it("keeps the earliest release of a month that has no first", () => {
+    const {keep} = partition([
+      ...feeds("2026-01-03", "2026-01-04", "2026-01-05"),
+      ...everyDay("2026-06-01", 40)
+    ]);
+
+    expect(keep).to.contain("feed-2026-01-03");
+    expect(keep).to.not.contain("feed-2026-01-04");
+  });
+
+  it("removes the dailies that are neither recent nor a month's first", () => {
+    const {remove} = partition(everyDay("2026-06-01", 120));
+
+    expect(remove).to.contain("feed-2026-06-15");
+    expect(remove).to.not.contain("feed-2026-06-01");
+  });
+
+  it("keeps and removes every feed release exactly once", () => {
+    const all = everyDay("2026-06-01", 120);
+    const {keep, remove} = partition(all);
+
+    expect([...keep, ...remove].sort()).to.deep.equal([...all].sort());
+  });
+
+  // The npm version tags live in the same release list. A pruner that could
+  // reach them is one bad regular expression away from deleting a release of
+  // the software.
+  it("never touches a tag that is not a feed", () => {
+    const {keep, remove} = partition([
+      "v6.6.15", "v6.6.14", "latest", "feed-2026-08-26", "feed-nightly", "feed-2026-8-1"
+    ]);
+
+    expect(keep).to.deep.equal(["feed-2026-08-26"]);
+    expect(remove).to.deep.equal([]);
+  });
+
+  it("does nothing with nothing", () => {
+    expect(partition([])).to.deep.equal({keep: [], remove: []});
+  });
+
+  // Every release is the earliest of its own month until a second one appears,
+  // so a naive rule keeps everything forever.
+  it("still prunes within a single month", () => {
+    const {keep, remove} = partition(everyDay("2026-06-01", 30), 5);
+
+    expect(keep).to.have.length(6);
+    expect(remove).to.have.length(24);
+    expect(keep).to.contain("feed-2026-06-01");
+    expect(keep).to.contain("feed-2026-06-30");
+  });
+
+});

--- a/scripts/vitest.config.mts
+++ b/scripts/vitest.config.mts
@@ -1,0 +1,13 @@
+import {defineProject} from "vitest/config";
+
+/**
+ * The workflow scripts. Not a package - they are run by CI with node, not
+ * imported by anything - but the pruner decides which published releases to
+ * delete, and that decision should not be discoverable only by watching it.
+ */
+export default defineProject({
+  test: {
+    name: "scripts",
+    include: ["*.spec.mjs"]
+  }
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,7 +7,8 @@ export default defineConfig({
   test: {
     projects: [
       "libs/*",
-      "apps/*"
+      "apps/*",
+      "scripts"
     ]
   }
 });


### PR DESCRIPTION
**E4.** A release a day, each carrying a 20 MB zip, accumulates forever. Two so far, so this is cheap to get right now and awkward later.

## The rule

Keep the **last 30 dailies**, plus the **earliest release of each month**. The last month is what anybody actually fetches; past that what is wanted is the ability to say what the feed looked like in April, and one release a month answers that as well as thirty do.

Earliest of the month rather than whichever is dated the 1st, so a night that failed to publish does not cost the whole month its record.

## It deletes published artifacts, so the rule is testable

`partition()` is pure and exported, with nine tests. `scripts/` gains a vitest project so it can have them — `check-validation.mjs` only reports and exits, but this one destroys things, and what it would remove should be readable without watching it remove anything.

One of those tests is that it considers **`feed-` tags only**. The npm version tags live in the same release list, and a pruner that could reach them is one bad regular expression away from deleting a release of the software. `v6.6.15`, `latest`, `feed-nightly` and `feed-2026-8-1` are all left alone.

Also checked against the real release list — it would remove nothing today:

```
all tags: feed-2026-08-26, feed-2026-08-25
keep:     feed-2026-08-26, feed-2026-08-25
REMOVE:   (none)
```

The step runs **after** the release, so a night that fails to publish prunes nothing.

There is one rule worth noting because a naive version gets it wrong: every release is the earliest of its own month until a second one appears, so "keep the first of each month" alone keeps everything forever. There is a test that pruning still happens within a single month.

## provenance.json joins the assets

E4's asset list, minus the tiering: `gtfs.zip`, `provenance.json`, `enrichment-report.json`, `validation.json`, `feed-meta.json`.

All four JSON files come **out** of the zip. They describe the feed rather than being part of it, and somebody unzipping a GTFS feed should get GTFS. `provenance.json` is attached only when an enricher ran, since that is when it exists.

No `gtfs-slim.zip` / `gtfs-full.zip` — deferred with the rest of D8 until there is a share-alike source to keep out of a permissive build. So the stable `releases/latest/download/gtfs.zip` link the site uses still resolves.

## Verification

- 437 tests (9 new), clean build, `yarn typecheck`
- Workflow YAML parses
- Dry run against the live release list, above
- E4 marked done in the plan; tally 52 → 53