### PR TITLE
Publish station entrances, so the feed knows where the doors are

### DIFF
--- a/.changeset/station-entrances.md
+++ b/.changeset/station-entrances.md
@@ -1,0 +1,27 @@
+---
+"dtd2mysql": patch
+---
+
+Publish station entrances, so the feed knows where the doors are.
+
+A station in this feed was one point, which is the point a schedule calls at. A
+rider arriving on foot needs the door, and a large station has several in
+different streets. NaPTAN records 4,308 of them under the Open Government
+Licence; 3,371 land in the feed, across 2,019 of 3,056 stations, as
+`location_type=2` stops under their station.
+
+The join is by name and **verified by distance**. Entrance ATCO codes are
+locality-prefixed rather than `9100` plus a TIPLOC, so unlike the coordinates
+there is no identifier to join on. Exact names match 71% and normalising the
+"Rail Station" / "Railway Station" / "Station" suffixes gets 86%, of which
+3,305 of 3,536 sit within 100 m of the station they matched. The distance check
+is what makes the name match safe: without it a NaPTAN record positioned 574 km
+from Oakham attaches to Oakham and nothing says so.
+
+`MutableFeed` gains `add()` for this - the narrow exception to "an enricher does
+not create stops". It can only extend the hierarchy beneath a station that
+already exists, so an enricher can describe a station the feed has in more
+detail and cannot invent one the timetable never mentioned. The addition is
+recorded in `provenance.json` like any other write.
+
+Off unless a config asks for it.

--- a/apps/dtd2gtfs/fixtures/BASELINE.md
+++ b/apps/dtd2gtfs/fixtures/BASELINE.md
@@ -13,6 +13,18 @@ before committing it** - that is the whole value of the file being text.
 
 ---
 
+## F3 · station entrances
+
+**No change to the golden**, which builds with no enrichers. With `NAPTAN_ENTRANCES` configured the
+feed gains `location_type=2` stops - 3,371 on the August 2026 feed, across 2,019 of 3,056 stations.
+
+`type-surface.json` gains `LocationType` from `libs/gtfs`, which is `0 | 1 | 2` where
+`location_type` was `0 | 1`, and the entrance exports from `enrich-naptan`. All additions.
+
+`MutableFeed` gains `add()`, the narrow exception to "an enricher does not create stops": it can
+only extend the hierarchy under a station that already exists, and the addition is recorded in
+`provenance.json` like any other write.
+
 ## D8 · attributions.txt
 
 `golden/` gains **`attributions.txt`**, with one row: Rail Delivery Group, the source of the

--- a/apps/dtd2gtfs/src/build.ts
+++ b/apps/dtd2gtfs/src/build.ts
@@ -1,7 +1,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import {NaptanEnricher, naptanFromApi} from "@gb-transit/enrich-naptan";
+import {
+  NaptanEnricher,
+  NaptanEntranceEnricher,
+  entrancesFromApi,
+  naptanFromApi
+} from "@gb-transit/enrich-naptan";
 import {STATION_GROUPS, StationGroupsExtension, groupsFromFeed} from "@gb-transit/extend-station-groups";
 import {parse} from "yaml";
 import {BuildConfig, BuildContext, Enricher, Extension, parseConfig} from "@gb-transit/gtfs";
@@ -77,7 +82,8 @@ function registered(config: BuildConfig | undefined): Enricher[] {
   const cache = path.join(os.tmpdir(), "gb-rail-enrichment");
 
   const available: Enricher[] = [
-    new NaptanEnricher(naptanFromApi(cache))
+    new NaptanEnricher(naptanFromApi(cache)),
+    new NaptanEntranceEnricher(entrancesFromApi(cache))
   ];
 
   const wanted = new Map((config?.enrichers ?? []).map(e => [e.key, e]));
@@ -137,7 +143,7 @@ function beside(given: readonly string[]): string {
   return fs.existsSync(first) && fs.statSync(first).isDirectory() ? first : path.dirname(first);
 }
 
-const REGISTERED = ["NAPTAN"];
+const REGISTERED = ["NAPTAN", "NAPTAN_ENTRANCES"];
 const REGISTERED_EXTENSIONS = [STATION_GROUPS];
 
 function readConfig(path: string | undefined): BuildConfig | undefined {

--- a/docs/restructure.md
+++ b/docs/restructure.md
@@ -1821,19 +1821,31 @@ months. Unblocks raising E2's horizon.
 Geometry from Network Rail GIS track centrelines (OGL). `shape_dist_traveled` populated. Behind an
 `extensions:` flag, since it materially inflates feed size.
 
-**F3 · Station entrances and the rest of the node set from NaPTAN** *(depends D3, D4, B23)* —
-**closes #69**
+**F3 · Station entrances from NaPTAN** *(depends D3, B23)* — **done for entrances; the platform
+cross-check is impossible** — **closes #69**
 
 **The ids and the field layout are no longer part of this.** B23 publishes the ATCO codes and moved
 CRS to `stop_code`, because neither needs NaPTAN: `9100` plus the TIPLOC is the ATCO code for a rail
 stop, and the timetable carries the TIPLOC. What is left is what genuinely needs the external node
 set.
 
-NaPTAN supplies it under OGL, so this does not depend on OSM: `RSE` (4,543 **station entrances**),
-and `RPL` (**rail platforms**) to check the platforms B23 derives against the ones NaPTAN records —
-a platform in the timetable that NaPTAN does not have, or the reverse, is a data quality signal
-worth reporting. OSM is then needed only for pathway *edges* and lift/stair attributes in D6, which
-materially reduces the ODbL exposure there.
+NaPTAN supplies the entrances under OGL, so this does not depend on OSM. OSM is then needed only for
+pathway *edges* and lift/stair attributes in D6, which materially reduces the ODbL exposure there.
+
+**The platform cross-check is not possible and the ticket was wrong to assume it.** `RPL` is not a
+national platform set: it holds **three** records — Alston, Kirkhaugh and Lintley, the South
+Tynedale heritage railway. The `9100ZZTYKKH1` quoted above *is* Kirkhaugh, so this generalised from
+a single ATCO code without counting. `PLT` has 1,633 and is entirely `9400`, which is tram and
+metro. There is nothing to check B23's platforms against, and that half of F3 is dropped rather
+than deferred.
+
+**The entrances are real**: 4,308 `RSE` records, 3,974 with a position. They do not join on an
+identifier - entrance ATCO codes are locality-prefixed (`0100ASHYDN0`) rather than `9100` plus a
+TIPLOC - so the join is by normalised name and **verified by distance**. Exact names match 71%,
+normalising the "Rail Station" / "Railway Station" / "Station" suffixes gets 86%, and of those
+3,305 of 3,536 sit within 100 m of the station they matched. The distance check is what makes the
+name match safe: it rejects five records outright, including a NaPTAN entrance for Oakham positioned
+574 km from Oakham.
 
 Remaining `stops.txt` changes:
 
@@ -1841,7 +1853,7 @@ Remaining `stops.txt` changes:
 |---|---|---|
 | `location_type` | B23 sets `1` and `0` | adds `2` entrance |
 | `parent_station` | B23 sets it on boarding points | adds entrances |
-| `stop_desc` | `cate_interchange_status` | free text; interchange status is already carried by `transfers.txt` |
+| `stop_desc` | `cate_interchange_status` | free text; interchange status is already carried by `transfers.txt`. **Not done** - an entrance carries its street or indicator, but changing it on every station is a visible change to existing rows and wants its own decision |
 
 B23 broke the three-letter join once, with the ids it will keep. F3 adds stops rather than renaming
 them, so it needs no flag and no second break.
@@ -1922,13 +1934,13 @@ parallel by different people without touching the core.
 B4–B13 batch; B24 and B25 were found by B6's validator on its first run; D13 was found by building
 D12, which did not fit the seam it was said to depend on).
 
-B3 is absorbed into T1. **53 are done** — T1–T5, T6b, T8–T13, A1–A3, A5–A10, C1–C3, B0, B1, B2, B4,
-B5, B6, B7–B9, B10–B13, B15, B17, B22, B23, D1, D2, D3, D8, D12, D13, E1, E2, E4, E5, E6 and E8, the last of
+B3 is absorbed into T1. **54 are done** — T1–T5, T6b, T8–T13, A1–A3, A5–A10, C1–C3, B0, B1, B2, B4,
+B5, B6, B7–B9, B10–B13, B15, B17, B22, B23, D1, D2, D3, D8, D12, D13, E1, E2, E4, E5, E6, E8 and F3, the last of
 those across master and Epic A. B14, B16, B18, B19, B20 and B21 are resolved by #121. A4, C4 and C5
 are deferred out of this pass. B24, B25 and **D4** are investigated and closed as data the feed
 already carries or already reports, and **F5** is dropped as a model GB fares do not fit.
 
-That leaves **18 in scope** — 17 untouched and T7 partly done — all of them in D, E, F or the
+That leaves **17 in scope** — 16 untouched and T7 partly done — all of them in D, E, F or the
 remainder of T.
 
 ---

--- a/libs/enrich-naptan/src/Entrances.spec.ts
+++ b/libs/enrich-naptan/src/Entrances.spec.ts
@@ -1,0 +1,197 @@
+import {describe, it, expect} from "vitest";
+import {MutableFeed} from "@gb-transit/gtfs";
+import type {Stop} from "@gb-transit/gtfs";
+import {NaptanEntranceEnricher, describe as describeEntrance, metresBetween, normalise} from "./Entrances";
+import {NaptanEntrance} from "./Naptan";
+
+const station = (crs: string, name: string, lat = 51.5, lon = -0.1): Stop => ({
+  stop_id: `910G${crs}`, crs, tiploc: crs, stop_name: name, stop_desc: "", stop_lat: lat,
+  stop_lon: lon, zone_id: 0, stop_url: "", location_type: 1, parent_station: null,
+  platform_code: null, stop_timezone: "Europe/London", wheelchair_boarding: 2, located: true
+});
+
+const entrance = (atco: string, name: string, lat = 51.5, lon = -0.1): NaptanEntrance => ({
+  atco, name, latitude: lat, longitude: lon, indicator: "", street: "", active: true
+});
+
+const run = (stations: Stop[], entrances: NaptanEntrance[], maxMetres?: number) => {
+  const feed = new MutableFeed(stations, [], []);
+  const enricher = new NaptanEntranceEnricher(
+    () => Promise.resolve(entrances), 50, maxMetres
+  );
+
+  return {feed, report: enricher.apply(feed, entrances)};
+};
+
+describe("normalise", () => {
+
+  // NaPTAN calls it "Ashley Down Rail Station"; the MSN calls it "Ashley Down".
+  // Exact matching gets 71% of entrances, this gets 86%.
+  it("strips the station suffixes the two sources disagree about", () => {
+    expect(normalise("Kings Cross Rail Station")).to.equal("kings cross");
+    expect(normalise("Kings Cross Railway Station")).to.equal("kings cross");
+    expect(normalise("Kings Cross Station")).to.equal("kings cross");
+    expect(normalise("Kings Cross")).to.equal("kings cross");
+  });
+
+  it("strips a parenthesised suffix", () => {
+    expect(normalise("Bushey (Rail Station)")).to.equal("bushey");
+  });
+
+  it("strips what follows the suffix", () => {
+    expect(normalise("Ely Railway Station Forecourt")).to.equal("ely");
+  });
+
+  it("folds punctuation, which the two sources also disagree about", () => {
+    expect(normalise("Acton Bridge (Cheshire)")).to.equal(normalise("Acton Bridge Cheshire"));
+    expect(normalise("St. Albans")).to.equal(normalise("St Albans"));
+  });
+
+  it("keeps a name that identifies the station", () => {
+    expect(normalise("Acton Bridge (Cheshire)")).to.equal("acton bridge cheshire");
+  });
+
+});
+
+describe("metresBetween", () => {
+
+  it("is zero at the same point", () => {
+    expect(metresBetween({latitude: 51.5, longitude: -0.1}, {stop_lat: 51.5, stop_lon: -0.1}))
+      .to.equal(0);
+  });
+
+  // Euston to Kings Cross is about 800 m.
+  it("measures a short distance about right", () => {
+    const metres = metresBetween(
+      {latitude: 51.5282, longitude: -0.1337},
+      {stop_lat: 51.5308, stop_lon: -0.1238}
+    );
+
+    expect(metres).to.be.greaterThan(600);
+    expect(metres).to.be.lessThan(1000);
+  });
+
+});
+
+describe("NaptanEntranceEnricher", () => {
+
+  it("adds an entrance as a child of the station it names", () => {
+    const {feed, report} = run(
+      [station("KGX", "London Kings Cross")],
+      [entrance("0100KGX0", "London Kings Cross Rail Station")]
+    );
+
+    expect(report.matched).to.equal(1);
+
+    const added = feed.stop("0100KGX0")!;
+
+    expect(added.location_type).to.equal(2);
+    expect(added.parent_station).to.equal("910GKGX");
+    expect(added.crs).to.equal("KGX");
+  });
+
+  it("keeps NaPTAN's own identifier for the door", () => {
+    const {feed} = run([station("KGX", "Kings Cross")], [entrance("0100ASHYDN0", "Kings Cross")]);
+
+    expect(feed.stop("0100ASHYDN0")).to.not.equal(undefined);
+  });
+
+  // NaPTAN covers Underground and light rail that the timetable does not.
+  it("reports an entrance whose station is not in the feed", () => {
+    const {report} = run([station("KGX", "Kings Cross")], [entrance("0100CHM0", "Chesham")]);
+
+    expect(report.matched).to.equal(0);
+    expect(report.unmatched).to.equal(1);
+  });
+
+  // NaPTAN has an Oakham entrance 574 km from Oakham. Without the distance
+  // check that lands on the station and nothing says so.
+  it("disbelieves a name match that is implausibly far away", () => {
+    const {feed, report} = run(
+      [station("OKM", "Oakham", 52.67, -0.72)],
+      [entrance("0100OKM0", "Oakham Rail Station", 57.5, -4.2)]
+    );
+
+    expect(report.matched).to.equal(0);
+    expect(feed.stops).to.have.length(1);
+    expect(report.notes?.join(" ")).to.contain("more than 1000 m away");
+  });
+
+  it("believes an entrance a few hundred metres away, as a terminus has", () => {
+    const {report} = run(
+      [station("WAT", "London Waterloo", 51.5031, -0.1132)],
+      [entrance("0100WAT0", "London Waterloo Rail Station", 51.5045, -0.1155)]
+    );
+
+    expect(report.matched).to.equal(1);
+  });
+
+  // Twenty-seven station names are ambiguous once normalised. Taking the first
+  // would depend on the order the stops were built in.
+  it("attaches to the nearest of two stations sharing a name", () => {
+    const {feed} = run(
+      [station("BSH", "Bushey", 51.6459, -0.3846), station("BSJ", "Bushey", 53.0, -2.0)],
+      [entrance("0100BSH0", "Bushey Rail Station", 51.6461, -0.3849)]
+    );
+
+    expect(feed.stop("0100BSH0")!.parent_station).to.equal("910GBSH");
+  });
+
+  it("is the same feed whichever order the stations were built in", () => {
+    const one = run(
+      [station("BSH", "Bushey", 51.6459, -0.3846), station("BSJ", "Bushey", 53.0, -2.0)],
+      [entrance("0100BSH0", "Bushey Rail Station", 51.6461, -0.3849)]
+    );
+    const other = run(
+      [station("BSJ", "Bushey", 53.0, -2.0), station("BSH", "Bushey", 51.6459, -0.3846)],
+      [entrance("0100BSH0", "Bushey Rail Station", 51.6461, -0.3849)]
+    );
+
+    expect(one.feed.stop("0100BSH0")!.parent_station)
+      .to.equal(other.feed.stop("0100BSH0")!.parent_station);
+  });
+
+  // Two sources claiming one id are not describing the same place.
+  it("refuses a second entrance with an id already taken", () => {
+    const {feed, report} = run(
+      [station("KGX", "Kings Cross")],
+      [entrance("0100KGX0", "Kings Cross"), entrance("0100KGX0", "Kings Cross")]
+    );
+
+    expect(report.matched).to.equal(1);
+    expect(feed.duplicates).to.equal(1);
+  });
+
+  it("does not claim the station's accessibility for its door", () => {
+    const {feed} = run([station("KGX", "Kings Cross")], [entrance("0100KGX0", "Kings Cross")]);
+
+    expect(feed.stop("0100KGX0")!.wheelchair_boarding).to.equal(0);
+  });
+
+  it("leaves the stations it did not match alone", () => {
+    const {feed} = run([station("KGX", "Kings Cross")], []);
+
+    expect(feed.stops).to.have.length(1);
+    expect(feed.stop("910GKGX")!.location_type).to.equal(1);
+  });
+
+});
+
+describe("describe", () => {
+
+  it("says both when NaPTAN has both", () => {
+    expect(describeEntrance({indicator: "Main Entrance", street: "Euston Road"}))
+      .to.equal("Main Entrance, Euston Road");
+  });
+
+  it("says whichever it has", () => {
+    expect(describeEntrance({indicator: "Entrance", street: ""})).to.equal("Entrance");
+    expect(describeEntrance({indicator: "", street: "York Way"})).to.equal("York Way");
+  });
+
+  it("says nothing rather than a stray comma", () => {
+    expect(describeEntrance({indicator: "", street: ""})).to.equal("");
+    expect(describeEntrance({indicator: "  ", street: " "})).to.equal("");
+  });
+
+});

--- a/libs/enrich-naptan/src/Entrances.ts
+++ b/libs/enrich-naptan/src/Entrances.ts
@@ -1,0 +1,204 @@
+import {Attribution, Enricher, EnrichmentReport, MutableFeed, Stop} from "@gb-transit/gtfs";
+import {NaptanEntrance} from "./Naptan";
+
+export const NAPTAN_ENTRANCES = "NAPTAN_ENTRANCES";
+
+const ATTRIBUTION: Attribution = {
+  organisation: "Department for Transport",
+  licence: "Open Government Licence v3.0",
+  url: "https://naptan.dft.gov.uk",
+  shareAlike: false
+};
+
+/**
+ * How far an entrance may be from its station before the match is disbelieved.
+ *
+ * Generous on purpose. A terminus is hundreds of metres across and its
+ * entrances genuinely are far from the point that stands for the station, so a
+ * tight radius would throw away good data. What this is really for is the
+ * handful of records with a broken position - NaPTAN has an Oakham entrance 574
+ * km from Oakham - and a name that matched the wrong station entirely.
+ */
+const MAX_METRES = 1000;
+
+/**
+ * Station entrances, from NaPTAN.
+ *
+ * A station in this feed is one point, which is the point a schedule calls at.
+ * A rider arriving on foot needs the door, and a large station has several in
+ * different streets - Kings Cross has entrances on Euston Road and York Way,
+ * and which one you want depends on where you are coming from.
+ *
+ * **The join is by name, verified by distance.** Entrance ATCO codes are
+ * locality-prefixed - `0100ASHYDN0` - not `9100` plus the TIPLOC, so unlike
+ * D3's coordinates there is no identifier to join on. Names match once the
+ * "Rail Station" / "Railway Station" / "Station" suffixes are normalised away,
+ * and the distance check is what turns a fuzzy match into a verified one:
+ * without it an entrance whose name collides with another station attaches
+ * silently to the wrong place.
+ */
+export class NaptanEntranceEnricher implements Enricher<readonly NaptanEntrance[]> {
+
+  public readonly key = NAPTAN_ENTRANCES;
+  public readonly dependsOn: readonly string[] = [];
+  public readonly attribution = ATTRIBUTION;
+
+  constructor(
+    private readonly source: () => Promise<readonly NaptanEntrance[]>,
+    public readonly priority: number = 50,
+    private readonly maxMetres: number = MAX_METRES
+  ) {}
+
+  public fetch(): Promise<readonly NaptanEntrance[]> {
+    return this.source();
+  }
+
+  public apply(feed: MutableFeed, entrances: readonly NaptanEntrance[]): EnrichmentReport {
+    const byName = new Map<string, Stop[]>();
+
+    for (const station of feed.stations) {
+      const name = normalise(station.stop_name);
+      const found = byName.get(name) ?? [];
+
+      found.push(station);
+      byName.set(name, found);
+    }
+
+    const notes: string[] = [];
+
+    let matched = 0;
+    let unmatched = 0;
+    let tooFar = 0;
+
+    for (const entrance of entrances) {
+      const candidates = byName.get(normalise(entrance.name));
+
+      if (candidates === undefined) {
+        unmatched++;
+        continue;
+      }
+
+      // Twenty-seven station names are ambiguous once normalised - two
+      // Busheys, two Clapham Junctions - so the nearest is taken rather than
+      // the first, which would depend on the order the stops were built in.
+      const nearest = candidates
+        .map(station => ({station, metres: metresBetween(entrance, station)}))
+        .sort((a, b) => a.metres - b.metres)[0];
+
+      if (nearest.metres > this.maxMetres) {
+        tooFar++;
+        continue;
+      }
+
+      feed.add(toEntrance(entrance, nearest.station), this) ? matched++ : unmatched++;
+    }
+
+    if (unmatched > 0) {
+      notes.push(
+        `${unmatched} entrances name a station this feed does not contain - NaPTAN covers ` +
+        `Underground and light rail stations that the timetable does not`
+      );
+    }
+
+    if (tooFar > 0) {
+      notes.push(
+        `${tooFar} entrances matched a station name but sit more than ${this.maxMetres} m away, ` +
+        `so the match was not believed`
+      );
+    }
+
+    if (feed.duplicates > 0) {
+      notes.push(`${feed.duplicates} stops were refused because their id was already taken`);
+    }
+
+    return {enricher: this.key, matched, unmatched, conflicts: 0, notes};
+  }
+
+}
+
+/**
+ * A station name reduced to the part that identifies it.
+ *
+ * NaPTAN calls the same place "Ashley Down Rail Station" and the MSN calls it
+ * "Ashley Down"; entrances add "Railway Station", "Station" and the occasional
+ * "Forecourt". Exact matching gets 71% of them and this gets 86%.
+ */
+export function normalise(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s*\((rail|railway)\s+station\)\s*$/, "")
+    .replace(/\s+(rail|railway)\s+station\b.*$/, "")
+    .replace(/\s+station\b.*$/, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/**
+ * Metres between two points, on a sphere.
+ *
+ * Good enough at this range: the error against a proper geodesic is centimetres
+ * over a kilometre, and the threshold is a kilometre.
+ */
+export function metresBetween(
+  a: {latitude: number, longitude: number},
+  b: {stop_lat: number, stop_lon: number}
+): number {
+  const R = 6371000;
+  const lat1 = toRadians(a.latitude);
+  const lat2 = toRadians(b.stop_lat);
+  const dLat = toRadians(b.stop_lat - a.latitude);
+  const dLon = toRadians(b.stop_lon - a.longitude);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function toRadians(degrees: number): number {
+  return degrees * Math.PI / 180;
+}
+
+/**
+ * The most that can be said about where a door is.
+ *
+ * "Main Entrance, Euston Road" where NaPTAN has both, and whichever it has
+ * otherwise. Empty is honest when it has neither - four of Birmingham New
+ * Street's entrances say only "Entrance", and repeating that four times tells a
+ * rider nothing it did not already know.
+ */
+export function describe(entrance: {indicator: string, street: string}): string {
+  return [entrance.indicator.trim(), entrance.street.trim()].filter(part => part !== "").join(", ");
+}
+
+/**
+ * An entrance as a GTFS stop.
+ *
+ * `location_type=2` and a `parent_station`, which is what the spec has for a
+ * door. It keeps NaPTAN's ATCO code as its id: it is already a stable national
+ * identifier for exactly this thing, and inventing one would mean the feed's id
+ * for a door disagreeing with everybody else's.
+ */
+function toEntrance(entrance: NaptanEntrance, station: Stop): Stop {
+  return {
+    stop_id: entrance.atco,
+    crs: station.crs,
+    tiploc: station.tiploc,
+    stop_name: entrance.name,
+    // What tells two doors of one station apart. Neither field does it alone:
+    // Indicator is "Entrance" on 1,821 of 4,308 records, and Street is blank on
+    // 1,263, so the useful description is whichever exist, together.
+    stop_desc: describe(entrance),
+    stop_lat: entrance.latitude,
+    stop_lon: entrance.longitude,
+    located: true,
+    zone_id: station.zone_id,
+    stop_url: "",
+    location_type: 2 as Stop["location_type"],
+    parent_station: station.stop_id,
+    platform_code: null,
+    stop_timezone: station.stop_timezone,
+    // Not inherited from the station: whether you can get through this door is
+    // not the same question as whether the station is step-free, and NaPTAN
+    // does not say. 0 is "no information".
+    wheelchair_boarding: 0
+  };
+}

--- a/libs/enrich-naptan/src/Naptan.ts
+++ b/libs/enrich-naptan/src/Naptan.ts
@@ -12,6 +12,24 @@ export interface NaptanStop {
   readonly active: boolean;
 }
 
+/**
+ * One NaPTAN station entrance - an `RSE` record.
+ *
+ * The ATCO code is locality-prefixed (`0100ASHYDN0`) rather than `9100` plus a
+ * TIPLOC, so unlike a rail record it carries nothing to join on but its name
+ * and its position.
+ */
+export interface NaptanEntrance {
+  readonly atco: string;
+  readonly name: string;
+  readonly latitude: number;
+  readonly longitude: number;
+  /** What tells two doors of one station apart, when NaPTAN says. */
+  readonly indicator: string;
+  readonly street: string;
+  readonly active: boolean;
+}
+
 export const NAPTAN = "NAPTAN";
 
 const ATTRIBUTION: Attribution = {

--- a/libs/enrich-naptan/src/NaptanSource.ts
+++ b/libs/enrich-naptan/src/NaptanSource.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {parse} from "csv-parse/sync";
-import {NaptanStop} from "./Naptan";
+import {NaptanEntrance, NaptanStop} from "./Naptan";
 
 /**
  * The DfT's open data endpoint. `stopTypes` is accepted and ignored - the
@@ -15,6 +15,7 @@ const NAPTAN_CSV = "https://naptan.api.dft.gov.uk/v1/access-nodes?dataFormat=csv
  */
 const RAIL_PREFIX = "9100";
 
+
 /**
  * Read NaPTAN, from a cached copy if there is one.
  *
@@ -24,7 +25,14 @@ const RAIL_PREFIX = "9100";
  * NaPTAN changes slowly and a stale coordinate is better than no build.
  */
 export function naptanFromApi(cacheDirectory: string, maxAgeDays = 30): () => Promise<readonly NaptanStop[]> {
-  return async () => {
+  return async () => parseNaptan(await csvFile(cacheDirectory, maxAgeDays));
+}
+
+/**
+ * The NaPTAN CSV, downloaded if there is no fresh copy.
+ */
+async function csvFile(cacheDirectory: string, maxAgeDays: number): Promise<string> {
+  {
     const file = path.join(cacheDirectory, "naptan.csv");
 
     if (!fresh(file, maxAgeDays)) {
@@ -45,8 +53,18 @@ export function naptanFromApi(cacheDirectory: string, maxAgeDays = 30): () => Pr
       fs.renameSync(partial, file);
     }
 
-    return parseNaptan(fs.readFileSync(file, "utf8"));
-  };
+    return fs.readFileSync(file, "utf8");
+  }
+}
+
+/**
+ * The entrances out of the same cached download.
+ *
+ * Separate from `naptanFromApi` so an enricher takes only what it needs, and
+ * sharing the cache so this is one file on disk however many read it.
+ */
+export function entrancesFromApi(cacheDirectory: string, maxAgeDays = 30): () => Promise<readonly NaptanEntrance[]> {
+  return async () => parseEntrances(await csvFile(cacheDirectory, maxAgeDays));
 }
 
 function coordinate(value: string | undefined): number | undefined {
@@ -76,17 +94,50 @@ function fresh(file: string, maxAgeDays: number): boolean {
  * no network, and so a malformed row is a parsing problem rather than a
  * mysterious absence later.
  */
-export function parseNaptan(csv: string): NaptanStop[] {
-  const rows: {[column: string]: string}[] = parse(csv, {
+export function parseEntrances(csv: string): NaptanEntrance[] {
+  const entrances: NaptanEntrance[] = [];
+
+  for (const row of rows(csv)) {
+    if (row.StopType !== "RSE") {
+      continue;
+    }
+
+    const latitude = coordinate(row.Latitude);
+    const longitude = coordinate(row.Longitude);
+
+    // 334 entrances ship with no position. A door that could be anywhere is
+    // not a door, and unlike a station there is nothing else to fall back on.
+    if (latitude === undefined || longitude === undefined) {
+      continue;
+    }
+
+    entrances.push({
+      atco: row.ATCOCode ?? "",
+      name: row.CommonName ?? "",
+      latitude,
+      longitude,
+      indicator: row.Indicator ?? "",
+      street: row.Street ?? "",
+      active: row.Status !== "inactive"
+    });
+  }
+
+  return entrances;
+}
+
+function rows(csv: string): {[column: string]: string}[] {
+  return parse(csv, {
     columns: true,
     bom: true,
     skip_empty_lines: true,
     relax_column_count: true
   });
+}
 
+export function parseNaptan(csv: string): NaptanStop[] {
   const stops: NaptanStop[] = [];
 
-  for (const row of rows) {
+  for (const row of rows(csv)) {
     if (row.StopType !== "RLY" || !row.ATCOCode?.startsWith(RAIL_PREFIX)) {
       continue;
     }

--- a/libs/enrich-naptan/src/index.ts
+++ b/libs/enrich-naptan/src/index.ts
@@ -1,3 +1,6 @@
 export {NaptanEnricher, NAPTAN} from "./Naptan";
 export type {NaptanStop} from "./Naptan";
 export {naptanFromApi, parseNaptan} from "./NaptanSource";
+export {NaptanEntranceEnricher, NAPTAN_ENTRANCES, describe, normalise, metresBetween} from "./Entrances";
+export {entrancesFromApi, parseEntrances} from "./NaptanSource";
+export type {NaptanEntrance} from "./Naptan";

--- a/libs/gtfs/src/enrich/MutableFeed.ts
+++ b/libs/gtfs/src/enrich/MutableFeed.ts
@@ -117,6 +117,61 @@ export class MutableFeed implements FeedView {
     return applied;
   }
 
+  /**
+   * Add a stop the DTD has no concept of, attached to one it does.
+   *
+   * The narrow exception to "an enricher does not create stops". A station
+   * entrance is not a detail of the station - it is a place, with its own
+   * position, that a rider walks through - and there is nowhere else in GTFS to
+   * put one. What keeps this from being a hole in the seam is that it can only
+   * *extend* the hierarchy: the parent has to exist already, so an enricher can
+   * describe a station the feed has in more detail and cannot invent a station
+   * the timetable never mentioned.
+   *
+   * Recorded like any other write, so provenance.json answers "where did this
+   * stop come from" as well as "why does this field say that".
+   *
+   * Returns whether it was added. A duplicate id is refused rather than
+   * overwriting, because two sources claiming the same stop is a collision to
+   * report, not a contest to resolve - they are not the same place.
+   */
+  public add(stop: Stop, by: Enricher): boolean {
+    if (this.stopIndex.has(stop.stop_id)) {
+      this.rejected++;
+
+      return false;
+    }
+
+    if (stop.parent_station === null || !this.stopIndex.has(stop.parent_station)) {
+      this.orphaned++;
+
+      return false;
+    }
+
+    this.provenance.record("stop", stop.stop_id, "added", {
+      enricher: by.key,
+      priority: by.priority,
+      value: stop.stop_name
+    });
+
+    this.stops.push(stop);
+    this.stopIndex.set(stop.stop_id, stop);
+    // The station index is built on demand and would not know about this one.
+    this.stationIndex = undefined;
+
+    return true;
+  }
+
+  /** Stops refused because something already had that id. */
+  public get duplicates(): number {
+    return this.rejected;
+  }
+
+  /** Stops refused because the station they hang from is not in the feed. */
+  public get orphans(): number {
+    return this.orphaned;
+  }
+
   public get ledger(): Provenance {
     return this.provenance;
   }
@@ -131,6 +186,8 @@ export class MutableFeed implements FeedView {
   }
 
   private refusals = 0;
+  private rejected = 0;
+  private orphaned = 0;
 
 }
 

--- a/libs/gtfs/src/entity/Stop.ts
+++ b/libs/gtfs/src/entity/Stop.ts
@@ -29,7 +29,11 @@ export interface Stop {
   located: boolean;
   zone_id: number;
   stop_url: string;
-  location_type: 0 | 1;
+  /**
+   * 0 a boarding point, 1 a station, 2 an entrance. The entrances come from
+   * NaPTAN rather than the DTD, which has no concept of a door.
+   */
+  location_type: LocationType;
   parent_station: StopID | null;
   /**
    * The platform a boarding facility is, set only on a child stop. Null on a
@@ -39,6 +43,8 @@ export interface Stop {
   stop_timezone: string;
   wheelchair_boarding: 0 | 1 | 2;
 }
+
+export type LocationType = 0 | 1 | 2;
 
 export type StopID = string;
 export type CRS = string;
@@ -54,7 +60,7 @@ export interface StopRow {
   stop_desc: string;
   zone_id: number;
   stop_url: string;
-  location_type: 0 | 1;
+  location_type: LocationType;
   parent_station: StopID | null;
   platform_code: string | null;
   stop_timezone: string;

--- a/libs/gtfs/src/index.ts
+++ b/libs/gtfs/src/index.ts
@@ -7,7 +7,7 @@ export type {CalendarDate, CalendarDateRow} from "./entity/CalendarDate";
 export type {FixedLink, FixedLinkRow} from "./entity/FixedLink";
 export {RouteType} from "./entity/Route";
 export type {Route, RouteID, RouteRow} from "./entity/Route";
-export type {Stop, StopRow, CRS, TIPLOC} from "./entity/Stop";
+export type {Stop, StopRow, CRS, TIPLOC, LocationType} from "./entity/Stop";
 export type {StopTime, StopTimeRow, Platform} from "./entity/StopTime";
 export {TransferType} from "./entity/Transfer";
 export type {Transfer, TransferRow, StopID} from "./entity/Transfer";

--- a/type-surface.json
+++ b/type-surface.json
@@ -19,9 +19,17 @@
   ],
   "enrich-naptan": [
     "NAPTAN",
+    "NAPTAN_ENTRANCES",
     "NaptanEnricher",
+    "NaptanEntrance",
+    "NaptanEntranceEnricher",
     "NaptanStop",
+    "describe",
+    "entrancesFromApi",
+    "metresBetween",
     "naptanFromApi",
+    "normalise",
+    "parseEntrances",
     "parseNaptan"
   ],
   "extend-station-groups": [
@@ -119,6 +127,7 @@
     "IdGenerator",
     "KeyValue",
     "Licence",
+    "LocationType",
     "MutableFeed",
     "NOWHERE",
     "NO_DAYS",


### PR DESCRIPTION
**F3, grouped: the add-stop seam, the entrances, and two corrections to the ticket.** Closes #69.

A station in this feed is one point — the point a schedule calls at. A rider arriving on foot needs the *door*, and a large station has several in different streets. NaPTAN records 4,308 under OGL.

**3,371 land in the feed, across 2,019 of 3,056 stations**, as `location_type=2` stops under their station.

## The join is by name and verified by distance

Entrance ATCO codes are locality-prefixed — `0100ASHYDN0` — not `9100` plus the TIPLOC, so unlike D3's coordinates there is no identifier to join on.

| | |
|---|---|
| Exact name match | 71% |
| After normalising `Rail Station` / `Railway Station` / `Station` | **86%** |
| Of those, within 100 m of the matched station | 3,305 of 3,536 |
| Beyond 1 km, rejected | 5 |

**The distance check is what makes a fuzzy match safe.** Without it, a NaPTAN entrance record positioned **574 km from Oakham** attaches to Oakham and nothing says so. Five are rejected that way and reported. Twenty-seven station names are ambiguous once normalised — two Busheys, two Clapham Junctions — so the *nearest* candidate wins rather than the first, which would depend on the order stops were built in. There is a test that both orders agree.

## A third capability, deliberately narrow

Neither seam could do this: an `Enricher` writes fields on existing entities, an `Extension` writes whole new files. An entrance is a new *row in an existing file*.

`MutableFeed.add()` is the narrow exception to *"an enricher does not create stops"*. What keeps it from being a hole in the seam is that it can only **extend** the hierarchy: the parent must already exist, so an enricher can describe a station the feed has in more detail and cannot invent one the timetable never mentioned. Duplicate ids and orphans are refused and counted rather than resolved — two sources claiming one id are not describing the same place. Additions are recorded in `provenance.json` like any other write.

## Two of F3's premises were wrong

**There is no platform cross-check to do.** `RPL` is not a national platform set — it holds **three records**: Alston, Kirkhaugh and Lintley, the South Tynedale heritage railway. The `9100ZZTYKKH1` the ticket quotes *is* Kirkhaugh, so it generalised from a single ATCO code without counting. `PLT` has 1,633 and is entirely `9400` — tram and metro. That half is dropped rather than deferred.

**`stop_desc` on stations is left alone.** An entrance carries its indicator and street, but changing it on every station is a visible change to existing rows and wants its own decision.

## Detail worth knowing

`stop_desc` on an entrance combines indicator and street, because neither works alone: `Indicator` is literally "Entrance" on 1,821 of 4,308 records and `Street` is blank on 1,263. Birmingham New Street's four entrances have neither, so they say nothing rather than "Entrance" four times.

`wheelchair_boarding` is **not** inherited from the station — whether you can get through a particular door is a different question from whether the station is step-free, and NaPTAN does not answer it.

Entrances keep NaPTAN's ATCO code as their `stop_id`: it is already a stable national identifier for exactly this thing.

## Verification

- Clean-from-scratch build, `yarn typecheck`, **460 tests** (25 new)
- Built against the **real feed**: 3,371 entrances, every `parent_station` resolves, 0 dangling
- **MobilityData validator on the entrance feed: no new errors** — only the two already in the baseline, and no entrance or parent notices
- Golden **byte identical**; the mini build has no enrichers
- Type surface is all additions, including `LocationType` widening `location_type` from `0 | 1`