### PR TITLE
Run the station groups extension in the nightly

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -84,6 +84,15 @@ jobs:
           yarn tsx apps/dtd2mysql/src/index.ts --download-timetable data/feeds/
           ls -la data/feeds/
 
+      # The station groups extension reads the fares refresh for its group
+      # membership. A failure here fails the build rather than quietly
+      # publishing a feed without areas.txt: a file that silently comes and goes
+      # is worse than one that is never there.
+      - name: Download the fares feed
+        run: |
+          yarn tsx apps/dtd2mysql/src/index.ts --download-fares data/feeds/
+          ls -la data/feeds/
+
       - name: Build the feed
         run: |
           mkdir -p feed

--- a/docs/restructure.md
+++ b/docs/restructure.md
@@ -1617,7 +1617,8 @@ The value is per *vehicle*, and the feed has trips, so the mapping depends on wh
 keyed by. Where nothing resolves, trips stay at `0` rather than inheriting a mode-level guess.
 Coverage report by operator, as D10.
 
-**D12 · `@gb-transit/extend-station-groups` — `areas.txt` and `stop_areas.txt`** — **done**
+**D12 · `@gb-transit/extend-station-groups` — `areas.txt` and `stop_areas.txt`** — **done, and in
+the nightly**
 
 RDG group stations: four-digit NLC groups such as `1072` "London Terminals" covering Euston,
 Waterloo, King's Cross and 15 others. Useful for journey planning and required for honest fares.
@@ -1654,7 +1655,11 @@ not depend on read order. The table does mix station groups with travelcard zone
 `area_name`, so the kind stays legible without this deciding which fares are real.
 
 On the August 2026 feed: **730 areas, 1,217 memberships, and 4 members out of 1,221 naming a station
-the feed does not contain.** One group has no member in the feed and is not published — an area with
+the feed does not contain.** The package shipped in #142 and the nightly did not run it until the
+config asked for it - `extensions:` was wired and then left empty, so the first published feed after
+it merged had no `areas.txt`. Turning it on also needed the workflow to download the **fares**
+refresh, which it never had: the timetable download alone leaves nothing for the extension to read
+and the build fails rather than quietly publishing a feed without the file. One group has no member in the feed and is not published — an area with
 no members cannot be told from one the build failed to resolve. `1072` comes out with all 18.
 
 **D12 did not fit D1.** An `Enricher` writes fields on entities the DTD already produced, through a

--- a/gtfs.config.yaml
+++ b/gtfs.config.yaml
@@ -31,3 +31,13 @@ enrichers:
       # feed called Newcastle Airport NEWCASTLE AIRPRT. 168 stations are
       # renamed; docs/station-names.md records where the two sources differ.
       - stop_name
+
+extensions:
+  # Group stations as GTFS Fares v2 areas: 1072 "London Terminals" is Euston,
+  # Waterloo, King's Cross and fifteen others, and a rider holding a ticket to
+  # it needs to know which stations that is.
+  #
+  # Membership comes from the fares refresh, which the workflow downloads
+  # alongside the timetable. With no `source` option the package looks beside
+  # the timetable feed, which is where it lands.
+  - STATION_GROUPS


### PR DESCRIPTION
`areas.txt` was missing from last night's feed. Two reasons, and fixing only the obvious one would have broken tonight's build.

## It was never switched on

The extension shipped in #142 — registered in the CLI, 16 tests, verified against the real fares feed. But `gtfs.config.yaml` has an `enrichers:` section and **no `extensions:` section at all**, so nothing ever asked for it. I wired the mechanism and left it off.

## Enabling it alone would have failed the build

Group membership comes from the **fares** refresh. The nightly runs `--download-timetable` and nothing else, so `data/feeds/` holds `RJTTF*.ZIP` only. With `extensions: [STATION_GROUPS]` and no fares feed, tonight's build stops with:

```
No fares refresh in data/feeds. Expected a file named RJFAFxxx.ZIP.
```

So the workflow now downloads the fares feed too. `--download-fares` goes through the same `feedCursor()` → `NO_CURSOR` path the timetable download was fixed to use, so it needs no database.

**A failed fares download fails the build** rather than skipping `areas.txt`. A file that silently comes and goes is worse than one that is never there, and it is the rule the validator gate already applies.

No `source` option is needed: the package looks beside the timetable feed by default, which is where the fares refresh lands. The CI cache uses `restore-keys: dtd-feeds-`, so an older refresh can persist alongside a new one — `faresRefresh` takes the highest-numbered, which is already tested.

## Verified against the real thing

Built with the actual `gtfs.config.yaml` and the real feeds, rather than a test config:

```
NAPTAN: matched 2622, unmatched 434, conflicts 0
  168 stations were renamed to what NaPTAN calls them
STATION_GROUPS: wrote 730, dropped 1 (areas.txt, stop_areas.txt)
```

730 areas, 1,217 memberships. Then through the release gate itself:

```
ERRORS: point_near_origin 2, stop_time_with_arrival_before_previous_departure_time 4
area notices: none
unlisted: none | grown: none
>>> RELEASE GATE WOULD PASS
```

Both errors are the ones `validator-baseline.json` already accepts. The validator raises nothing about `areas.txt` or `stop_areas.txt`.

Tonight's feed will also carry the 168 NaPTAN station renames, which is the first run since that config change.