### PR TITLE
Move the route branding into data

### DIFF
--- a/.changeset/branded-routes.md
+++ b/.changeset/branded-routes.md
@@ -1,0 +1,39 @@
+---
+"dtd2mysql": patch
+"@gb-transit/gtfs": minor
+---
+
+Publish routes as the brands a passenger sees, with stable ids.
+
+A route used to be one operator's journey between two places - `SE:TON->SEV:2` -
+numbered in the order the routes were written, so `routes.txt` ran to thousands
+of rows and a `route_id` meant nothing outside the build it came from. A route
+is now the brand on the departure board: `GW` is Great Western Railway, `WIN` is
+the Windrush line, `SX` is the Stansted Express. The id is worked out from the
+schedule, so it is the same id in every build and can be referred to from
+outside the feed.
+
+`route_short_name` and `route_long_name` are the operator's own names for the
+brand, `route_color` is the colour it uses on a route map and
+`route_text_color` is black or white, whichever can be read on it. The six
+operators that run more than one line - London Underground, the Overground,
+Merseyrail, the Tyne & Wear Metro, West Midlands Trains and Greater Anglia's
+Stansted Express - have their line worked out from where the service calls;
+`libs/gtfs/src/data/route.ts` holds the rules and the branding, and is the one
+file to edit when a brand changes. Buses and replacement buses keep routes of
+their own, because neither runs on the line its operator's trains do.
+
+`route_desc` is no longer written. It carried the class and reservation
+availability of a train, which is a property of the train and not of the line it
+runs on: trips sharing a route disagreed about it.
+
+For a consumer of `@gb-transit/gtfs`: `RouteID` is a string rather than a
+number, `Trip.route_id` with it, and the optional fields of `Route` are `null`
+rather than `undefined`, as everywhere else in the feed. `Schedule.toTrip` no
+longer takes a route number, and `Schedule.routeShortName` is `Schedule.routeId`.
+
+An operator the build has no agency for keeps its ATOC code, so it gets a route
+of its own named after that code and attributed to the catch-all `ZZ` agency.
+That route keeps its id when the agency list catches up with the operator, which
+is the case a stable id is for: `LF` ran before the software knew about Lumo
+(West Coast).

--- a/libs/gtfs/src/build/BuildFeed.ts
+++ b/libs/gtfs/src/build/BuildFeed.ts
@@ -276,10 +276,12 @@ export class BuildFeed {
     const stopTimes = this.output.open(`${this.baseDir}/stop_times.txt`);
     const routeFile = this.output.open(`${this.baseDir}/routes.txt`);
 
+    // Sorted by route ID, which a schedule works out for itself, so routes.txt
+    // does not depend on the order the schedules arrived in.
     const routes = chooseRoutes(schedules);
-    
-    for (const name of [...routes.keys()].sort()) {
-      this.write(routeFile, toRouteRow(routes.get(name)!));
+
+    for (const id of [...routes.keys()].sort()) {
+      this.write(routeFile, toRouteRow(routes.get(id)!));
     }
 
     // Sorting the schedules by trip ID sorts trips.txt, and sorts stop_times.txt
@@ -421,7 +423,18 @@ function ascending(a: Value, b: Value): number {
 }
 
 /**
- * Generate a map of routes, keyed by their id, from the schedules provided.
+ * The routes the schedules run on, keyed by their id.
+ *
+ * Every field of a Route but its type comes from the id, which the schedule
+ * works out for itself, so schedules sharing an id describe the same route and
+ * the last one to arrive can be kept.
+ *
+ * The type is the exception: only buses take an id of their own, so an operator
+ * running two other modes - trains and a ferry, say - has one id for both and
+ * whichever schedule arrives last says what the route is. Unresolved.
+ *
+ * Schedules with one call or none are skipped, because trips.txt skips them
+ * too and a route nothing refers to would be a dangling row.
  */
 function chooseRoutes(schedules: Schedule[]): Map<string, Route> {
   const chosen = new Map<string, Route>();
@@ -430,11 +443,12 @@ function chooseRoutes(schedules: Schedule[]): Map<string, Route> {
     if (schedule.stopTimes.length <= 1) {
       continue;
     }
-    
+
     const route = schedule.toRoute();
+
     chosen.set(route.route_id, route);
   }
-  
+
   return chosen;
 }
 

--- a/libs/gtfs/src/build/ScheduleBuilder.spec.ts
+++ b/libs/gtfs/src/build/ScheduleBuilder.spec.ts
@@ -123,6 +123,27 @@ describe("ScheduleBuilder", () => {
     expect(message).to.equal("connection lost");
   });
 
+  /**
+   * An operator the build has no agency for keeps its ATOC code, so it gets a
+   * route of its own rather than sharing one with every other operator the
+   * build does not know. The route is attributed to the catch-all agency until
+   * the agency list catches up, and keeps its id when it does - which is what
+   * matters when an operator starts running before the software knows about it.
+   *
+   * Only a schedule with no code at all is ZZ.
+   */
+  it("keeps an ATOC code the build has no agency for", () => {
+    const builder = new ScheduleBuilder();
+
+    builder.load([
+      row({ id: 1, stop_id: 10, atoc_code: "SE" }),
+      row({ id: 2, stop_id: 11, atoc_code: "QQ" }),
+      row({ id: 3, stop_id: 12, atoc_code: null })
+    ]);
+
+    expect(builder.results.schedules.map(s => s.operator)).to.deep.equal(["SE", "QQ", "ZZ"]);
+  });
+
 });
 
 describe("ScheduleBuilder ordering contract", () => {

--- a/libs/gtfs/src/build/ScheduleBuilder.ts
+++ b/libs/gtfs/src/build/ScheduleBuilder.ts
@@ -4,7 +4,6 @@ import {RouteType} from "../entity/Route";
 import {NO_DAYS, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {ScheduleStopTimeRow} from "../source/TimetableSource";
 import {StopTime} from "../entity/StopTime";
-import {agencies} from "../data/agency";
 
 const pickupActivities = ["T ", "TB", "U "];
 const dropOffActivities = ["T ", "TF", "D "];

--- a/libs/gtfs/src/data/agency.ts
+++ b/libs/gtfs/src/data/agency.ts
@@ -1,5 +1,5 @@
 
-import {Agency} from "../entity/Agency";
+import {Agency, AgencyID} from "../entity/Agency";
 
 export const agencies: Agency[] = [
 { agency_id: "AW", agency_name: "Transport for Wales",        agency_url: "https://tfw.wales/",                      agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "0333 321 1202",  agency_fare_url: null },
@@ -44,3 +44,13 @@ export const agencies: Agency[] = [
 { agency_id: "QV", agency_name: "Arriva Bus",                 agency_url: "https://www.arrivabus.co.uk/",            agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "0344 800 4411",  agency_fare_url: null },
 { agency_id: "ZZ", agency_name: "Other operator",             agency_url: "https://www.nationalrail.co.uk/",         agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "0345 748 4950",  agency_fare_url: null },
 ];
+
+/**
+ * The agencies by their ATOC code.
+ *
+ * Every schedule asks whether its operator is one of these and what it is
+ * called, so the lookup is built once rather than walked per schedule.
+ */
+export const agencyIndex: ReadonlyMap<AgencyID, Agency> = new Map(
+  agencies.map(agency => [agency.agency_id, agency])
+);

--- a/libs/gtfs/src/data/route.ts
+++ b/libs/gtfs/src/data/route.ts
@@ -151,9 +151,11 @@ const WHITE = "FFFFFF";
 /**
  * Black or white, whichever can be read on the colour given.
  *
- * GTFS defaults `route_text_color` to black, which is unreadable on the darker
- * half of the palette above. The threshold is the WCAG 2.1 relative luminance
- * of a colour whose contrast with black and with white is equal.
+ * Written for every route that has a colour rather than left to the consumer,
+ * because a consumer that falls back to a colour of its own has no way to know
+ * that half the palette above is dark enough for black text to disappear into.
+ * The threshold is the WCAG 2.1 relative luminance at which the contrast with
+ * black and the contrast with white are equal.
  */
 export function accessibleTextColor(hex: string): string {
   const channel = (offset: number) => parseInt(hex.substring(offset, offset + 2), 16) / 255;

--- a/libs/gtfs/src/data/route.ts
+++ b/libs/gtfs/src/data/route.ts
@@ -1,0 +1,164 @@
+import {AgencyID} from "../entity/Agency";
+import {CRS} from "../entity/Stop";
+
+/**
+ * How a route is presented: the brand a passenger sees on a departure board,
+ * and the colour it is drawn in on a route map.
+ *
+ * Keyed by the id `Schedule.bareRouteId` arrives at, which is an ATOC code for
+ * an operator that runs one brand and a line code for one that runs several.
+ *
+ * A route with no entry here still gets a name, from the agency it belongs to.
+ * The entry is what makes it a brand rather than an operator.
+ *
+ * Names and colours are the operators' own, taken from their public branding.
+ * Colours are six hex digits without a leading hash, as GTFS writes them.
+ */
+export interface RouteBranding {
+  route_short_name?: string;
+  route_long_name?: string;
+  route_color?: string;
+  route_url?: string;
+}
+
+export const routeBranding: ReadonlyMap<string, RouteBranding> = new Map(Object.entries({
+  "AW": {route_short_name: "TfW Rail", route_long_name: "Transport for Wales", route_color: "ff0000"},
+  "CC": {route_long_name: "c2c", route_color: "b7007c"},
+  "CH": {route_long_name: "Chiltern Railways", route_color: "00bfff"},
+  "CS": {route_long_name: "Caledonian Sleeper", route_color: "1d2e35"},
+  "EM": {route_short_name: "EMR", route_long_name: "East Midlands Railway", route_color: "713563"},
+  "ES": {route_long_name: "Eurostar", route_color: "ffd700"},
+  "GC": {route_long_name: "Grand Central", route_color: "1d1d1b"},
+  "GN": {route_long_name: "Great Northern", route_color: "0099ff"},
+  "GR": {route_short_name: "LNER", route_long_name: "London North Eastern Railway", route_color: "ce0e2d"},
+  "GW": {route_short_name: "GWR", route_long_name: "Great Western Railway", route_color: "0a493e"},
+  "GX": {route_long_name: "Gatwick Express", route_color: "eb1e2d"},
+  "HT": {route_long_name: "Hull Trains", route_color: "de005c"},
+  "HX": {route_long_name: "Heathrow Express", route_color: "532e63"},
+  "IL": {route_long_name: "Island Line", route_color: "1e90ff"},
+  "LD": {route_long_name: "Lumo", route_color: "2b6ef5"},
+  "LE": {route_long_name: "Greater Anglia", route_color: "d70428"},
+  "LF": {route_long_name: "Lumo Stirling", route_color: "2b6ef5"},
+  "LM": {route_short_name: "WMT", route_long_name: "West Midlands Trains"},
+  "LN": {route_short_name: "LNR", route_long_name: "London Northwestern Railway", route_color: "00bf6f", route_url: "https://www.londonnorthwesternrailway.co.uk/"},
+  "LO": {route_short_name: "Overground", route_long_name: "London Overground", route_color: "ff7518"},
+  "LT": {route_short_name: "Underground", route_long_name: "London Underground", route_color: "000f9f"},
+  "ME": {route_long_name: "Merseyrail", route_color: "fff200"},
+  "NT": {route_long_name: "Northern", route_color: "0f0d78"},
+  "SE": {route_long_name: "Southeastern", route_color: "389cff"},
+  "SN": {route_long_name: "Southern", route_color: "8cc63e"},
+  "SR": {route_long_name: "ScotRail", route_color: "1e467d"},
+  "SW": {route_short_name: "SWR", route_long_name: "South Western Railway", route_color: "24398c"},
+  "SX": {route_long_name: "Stansted Express", route_color: "6b717a"},
+  "TL": {route_long_name: "Thameslink", route_color: "ff5aa4"},
+  "TP": {route_short_name: "TPE", route_long_name: "TransPennine Express", route_color: "09a4ec"},
+  "TW": {route_short_name: "Metro", route_long_name: "Tyne & Wear Metro"},
+  "VT": {route_short_name: "Avanti", route_long_name: "Avanti West Coast", route_color: "004354"},
+  "WM": {route_short_name: "WMR", route_long_name: "West Midlands Railway", route_color: "e07709", route_url: "https://www.westmidlandsrailway.co.uk/"},
+  "XC": {route_long_name: "CrossCountry", route_color: "660f21"},
+  "XR": {route_long_name: "Elizabeth line", route_color: "9364cc", route_url: "https://tfl.gov.uk/elizabeth-line/route/elizabeth/"},
+  "BAK": {route_short_name: "Bakerloo", route_color: "a65a2a", route_url: "https://tfl.gov.uk/tube/route/bakerloo/"},
+  "DST": {route_short_name: "District", route_color: "007934", route_url: "https://tfl.gov.uk/tube/route/district/"},
+  "MET": {route_short_name: "Metropolitan", route_color: "870f54", route_url: "https://tfl.gov.uk/tube/route/metropolitan/"},
+  "LIB": {route_short_name: "Liberty", route_color: "61686B", route_url: "https://tfl.gov.uk/overground/route/liberty/"},
+  "LIO": {route_short_name: "Lioness", route_color: "FFA600", route_url: "https://tfl.gov.uk/overground/route/lioness/"},
+  "MIL": {route_short_name: "Mildmay", route_color: "006FE6", route_url: "https://tfl.gov.uk/overground/route/mildmay/"},
+  "SUF": {route_short_name: "Suffragette", route_color: "18A95D", route_url: "https://tfl.gov.uk/overground/route/suffragette/"},
+  "WEA": {route_short_name: "Weaver", route_color: "9B0058", route_url: "https://tfl.gov.uk/overground/route/weaver/"},
+  "WIN": {route_short_name: "Windrush", route_color: "DC241F", route_url: "https://tfl.gov.uk/overground/route/windrush/"},
+  "ME_Northern": {route_short_name: "Northern", route_color: "0266b2", route_url: "https://www.merseytravel.gov.uk/timetables/rail/northern-line/"},
+  "ME_Wirral": {route_short_name: "Wirral", route_color: "00a94f", route_url: "https://www.merseytravel.gov.uk/timetables/rail/wirral-line/"},
+  "GRN": {route_short_name: "Green", route_color: "32B457"},
+  "YEL": {route_short_name: "Yellow", route_color: "FCB828"},
+}));
+
+/**
+ * Which line of a multi-line operator a service runs on, worked out from where
+ * it goes.
+ *
+ * The DTD feed names the operator and nothing finer, so the line has to be
+ * recovered from the calls. Each rule names stations that only its line serves:
+ * a Weaver line service is one that calls at Liverpool Street or Chingford,
+ * because no other Overground line does.
+ *
+ * The rules are ordered and the first that matches wins, so a service reaching
+ * more than one line's stations takes the line listed first. Only rules for the
+ * schedule's own operator are considered, so a code appearing under two
+ * operators is not a conflict.
+ *
+ * A service matching no rule keeps its operator's own id, which is the right
+ * answer for the operators that run one line and the honest one for a service
+ * whose line cannot be told from where it calls.
+ */
+export interface LineRule {
+  /** The ATOC code of the operator this rule reads. */
+  operator: AgencyID;
+  /** The id the matching service takes, which `routeBranding` names. */
+  line: string;
+  /** Matches a service starting or finishing at any of these. */
+  between?: CRS[];
+  /** Matches a service calling at any of these, at either end or in between. */
+  calls?: CRS[];
+}
+
+export const lineRules: readonly LineRule[] = [
+  // West Midlands Trains runs two brands, told apart by where the service ends
+  // rather than by where it calls. Everything that is not London Northwestern
+  // is West Midlands Railway, which is what the rule without a condition says.
+  {operator: "LM", line: "LN", between: ["EUS", "WFJ", "TRI", "BLY", "MKC", "NMP", "SAA", "BDM", "LIV", "CRE"]},
+  {operator: "LM", line: "WM"},
+
+  // A Greater Anglia service to or from Stansted Airport is the Stansted
+  // Express when it runs down the line to London, and an ordinary service to
+  // Cambridge or Peterborough when it does not.
+  {operator: "LE", line: "SX", between: ["SSD"], calls: ["LST", "SRA", "SVS", "TOM"]},
+
+  {operator: "LO", line: "WEA", calls: ["LST", "HAC", "SKW", "EDR", "ENF", "CHN", "WST", "CHI"]},
+  // Some Suffragette line services run through to Willesden Junction.
+  {operator: "LO", line: "SUF", calls: ["HRY", "WMW", "LER", "BKG"]},
+  {operator: "LO", line: "LIB", calls: ["RMF", "UPM"]},
+  // Stratford to Watford through services are taken to be the Lioness line;
+  // the ones terminating at Willesden Junction are not.
+  {operator: "LO", line: "LIO", calls: ["SBP", "HRW", "WFH", "WFJ"]},
+  {operator: "LO", line: "MIL", calls: ["KPA", "SPB", "RMD", "SAT", "HDH", "CMD", "HKC", "SRA"]},
+  {operator: "LO", line: "WIN", calls: ["DLJ", "SDC", "ZCW", "SQE", "NXG", "NWX", "SYD", "WCY", "CYP"]},
+  {operator: "LO", line: "LIO", calls: ["EUS", "KBN", "QPW"]},
+
+  {operator: "ME", line: "ME_Northern", calls: ["HNX", "LPY", "SDL", "BAH", "HLR", "SOP", "KKD", "WAO", "MAG", "OMS", "RIL", "KIR", "HBL", "AIN"]},
+  {operator: "ME", line: "ME_Wirral", calls: ["BKQ", "NBN", "BID", "WKI", "RFY", "PSL", "HOO", "ELP", "CTR"]},
+
+  {operator: "LT", line: "MET", calls: ["AMR", "ZCM", "RIC", "ZMP", "HOH", "ZBS"]},
+  {operator: "LT", line: "DST", calls: ["RMD", "GUN", "ZTU"]},
+  {operator: "LT", line: "BAK", calls: ["QPW", "SBP", "HRW"]},
+
+  // No Yellow line service appears in the National Rail timetable, so there is
+  // no rule for one.
+  {operator: "TW", line: "GRN", calls: ["APN", "FEG", "REG", "SUN"]},
+];
+
+/**
+ * The rules an operator has, in the order they are written. Built once: the
+ * lookup happens per schedule, and there are hundreds of thousands of those.
+ */
+export const lineRulesByOperator: ReadonlyMap<AgencyID, readonly LineRule[]> = lineRules.reduce(
+  (index, rule) => index.set(rule.operator, [...index.get(rule.operator) ?? [], rule]),
+  new Map<AgencyID, LineRule[]>()
+);
+
+const BLACK = "000000";
+const WHITE = "FFFFFF";
+
+/**
+ * Black or white, whichever can be read on the colour given.
+ *
+ * GTFS defaults `route_text_color` to black, which is unreadable on the darker
+ * half of the palette above. The threshold is the WCAG 2.1 relative luminance
+ * of a colour whose contrast with black and with white is equal.
+ */
+export function accessibleTextColor(hex: string): string {
+  const channel = (offset: number) => parseInt(hex.substring(offset, offset + 2), 16) / 255;
+  const linear = (c: number) => c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  const luminance = 0.2126 * linear(channel(0)) + 0.7152 * linear(channel(2)) + 0.0722 * linear(channel(4));
+
+  return luminance > 0.179 ? BLACK : WHITE;
+}

--- a/libs/gtfs/src/entity/Route.ts
+++ b/libs/gtfs/src/entity/Route.ts
@@ -4,13 +4,13 @@ import {AgencyID} from "./Agency";
 export interface Route {
   route_id: RouteID;
   agency_id: AgencyID;
-  route_short_name: string | undefined;
-  route_long_name: string | undefined;
+  route_short_name: string | null;
+  route_long_name: string | null;
   route_type: RouteType;
-  route_text_color: string | undefined;
-  route_color: string | undefined;
-  route_url: string | undefined;
-  route_desc: string | undefined;
+  route_text_color: string | null;
+  route_color: string | null;
+  route_url: string | null;
+  route_desc: string | null;
 }
 
 export enum RouteType {

--- a/libs/gtfs/src/model/Schedule.spec.ts
+++ b/libs/gtfs/src/model/Schedule.spec.ts
@@ -3,6 +3,10 @@ import {STP} from "../model/OverlayRecord";
 import {Days, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {schedule} from "../transform/MergeSchedules.spec";
 import {StopTime} from "../entity/StopTime";
+import {Schedule} from "./Schedule";
+import {RouteType} from "../entity/Route";
+import {AgencyID} from "../entity/Agency";
+import {CRS} from "../entity/Stop";
 
 describe("Schedule", () => {
 
@@ -27,7 +31,128 @@ describe("Schedule", () => {
 
 });
 
+describe("the route a schedule runs on", () => {
+
+  it("is the operator, for one that runs a single brand", () => {
+    expect(service("GW", ["PNZ", "PAD"]).routeId).to.equal("GW");
+  });
+
+  it("is the line, for an operator that runs several", () => {
+    // Richmond to Stratford is the Mildmay line, and only that.
+    expect(service("LO", ["RMD", "SRA"]).routeId).to.equal("MIL");
+  });
+
+  it("takes the first line whose stations it reaches", () => {
+    // A service reaching two lines' stations - Watford Junction is Lioness and
+    // Stratford is Mildmay - takes whichever rule is written first.
+    expect(service("LO", ["WFJ", "SBP", "SRA"]).routeId).to.equal("LIO");
+    expect(service("LT", ["RIC", "ZTU"]).routeId).to.equal("MET");
+    expect(service("LT", ["RMD", "ZTU"]).routeId).to.equal("DST");
+  });
+
+  it("tells the West Midlands Trains brands apart by where the service ends", () => {
+    expect(service("LM", ["BHM", "EUS"]).routeId).to.equal("LN");
+    expect(service("LM", ["BHM", "SHR"]).routeId).to.equal("WM");
+  });
+
+  it("is the Stansted Express only when the airport service runs to London", () => {
+    expect(service("LE", ["SSD", "TOM", "LST"]).routeId).to.equal("SX");
+    expect(service("LE", ["SSD", "CBG"]).routeId).to.equal("LE");
+  });
+
+  it("separates a bus and a replacement bus from the trains", () => {
+    expect(service("GW", ["PNZ", "PAD"], RouteType.Bus).routeId).to.equal("GW_BUS");
+    expect(service("GW", ["PNZ", "PAD"], RouteType.ReplacementBus).routeId).to.equal("GW_RRB");
+  });
+
+  it("is the same route however the schedule reached it", () => {
+    const east = service("LO", ["SRA", "KNR", "RMD"]);
+    const west = service("LO", ["RMD", "KNR", "SRA"]);
+
+    expect(east.routeId).to.equal(west.routeId);
+    expect(east.toRoute()).to.deep.equal(west.toRoute());
+  });
+
+});
+
+describe("a schedule as a GTFS route", () => {
+
+  it("is named as the brand names itself", () => {
+    expect(service("GW", ["PNZ", "PAD"]).toRoute()).to.contain({
+      route_id: "GW",
+      agency_id: "GW",
+      route_short_name: "GWR",
+      route_long_name: "Great Western Railway",
+      route_url: null
+    });
+  });
+
+  it("takes its name from the agency, for an operator with no brand entry", () => {
+    expect(service("QC", ["LAR"], RouteType.Ferry)).to.satisfy((s: Schedule) => {
+      const route = s.toRoute();
+
+      return route.route_short_name === null && route.route_long_name === "Caledonian MacBrayne";
+    });
+  });
+
+  it("falls back to the route id for an operator it has never heard of", () => {
+    expect(service("QQ", ["TON", "SEV"]).toRoute()).to.contain({
+      route_id: "QQ",
+      // Not an agency, so not one that can be published as one.
+      agency_id: "ZZ",
+      route_short_name: "QQ",
+      route_long_name: null
+    });
+  });
+
+  it("writes text that can be read on the colour it is drawn in", () => {
+    // The Northern line's blue takes white text.
+    expect(service("ME", ["HNX", "SDL"]).toRoute()).to.contain({
+      route_color: "0266b2",
+      route_text_color: "FFFFFF"
+    });
+    // A Merseyrail service whose calls name no line keeps the operator's own
+    // colour, which is a yellow that takes black text.
+    expect(service("ME", ["LVC", "LIV"]).toRoute()).to.contain({
+      route_color: "fff200",
+      route_text_color: "000000"
+    });
+  });
+
+  it("says nothing about a route it has no colour for", () => {
+    expect(service("TW", ["MTS", "SBN"]).toRoute()).to.contain({
+      route_color: null,
+      route_text_color: null
+    });
+  });
+
+});
+
 const ALL_DAYS: Days = { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
+
+/**
+ * A schedule that is only the things a route is worked out from: who runs it,
+ * how, and where it calls.
+ */
+function service(operator: AgencyID, calls: CRS[], mode: RouteType = RouteType.Rail): Schedule {
+  return new Schedule(
+    1,
+    calls.map((crs, i) => ({...stop(crs, "00:30"), stop_sequence: i + 1})),
+    "A",
+    "",
+    new ScheduleCalendar(
+      Temporal.PlainDate.from("2017-01-01"),
+      Temporal.PlainDate.from("2017-01-31"),
+      ALL_DAYS,
+      {}
+    ),
+    mode,
+    operator,
+    STP.Permanent,
+    false,
+    false
+  );
+}
 
 function stop(stopId: string, time: string): StopTime {
   return {

--- a/libs/gtfs/src/model/Schedule.spec.ts
+++ b/libs/gtfs/src/model/Schedule.spec.ts
@@ -40,14 +40,16 @@ describe("the route a schedule runs on", () => {
   it("is the line, for an operator that runs several", () => {
     // Richmond to Stratford is the Mildmay line, and only that.
     expect(service("LO", ["RMD", "SRA"]).routeId).to.equal("MIL");
+    // Rickmansworth to Baker Street is the Metropolitan, Richmond to Turnham
+    // Green the District.
+    expect(service("LT", ["RIC", "ZBS"]).routeId).to.equal("MET");
+    expect(service("LT", ["RMD", "ZTU"]).routeId).to.equal("DST");
   });
 
   it("takes the first line whose stations it reaches", () => {
     // A service reaching two lines' stations - Watford Junction is Lioness and
     // Stratford is Mildmay - takes whichever rule is written first.
     expect(service("LO", ["WFJ", "SBP", "SRA"]).routeId).to.equal("LIO");
-    expect(service("LT", ["RIC", "ZTU"]).routeId).to.equal("MET");
-    expect(service("LT", ["RMD", "ZTU"]).routeId).to.equal("DST");
   });
 
   it("tells the West Midlands Trains brands apart by where the service ends", () => {

--- a/libs/gtfs/src/model/Schedule.ts
+++ b/libs/gtfs/src/model/Schedule.ts
@@ -6,7 +6,8 @@ import {AgencyID} from "../entity/Agency";
 import {CRS} from "../entity/Stop";
 import {OverlayRecord, RSID, STP, TUID} from "./OverlayRecord";
 import {toYYYYMMDD} from "./PlainDate";
-import {agencies} from "../data/agency";
+import {agencyIndex} from "../data/agency";
+import {accessibleTextColor, LineRule, lineRulesByOperator, routeBranding} from "../data/route";
 
 /**
  * The identifier for a trip, stable across data revisions.
@@ -17,82 +18,6 @@ import {agencies} from "../data/agency";
  */
 export function tripId(tuid: TUID, calendar: ScheduleCalendar): string {
   return `${tuid}_${toYYYYMMDD(calendar.runsFrom)}_${toYYYYMMDD(calendar.runsTo)}`;
-}
-
-const BLACK = "000000";
-const WHITE = "FFFFFF";
-
-function getAccessibleTextColor(hex : string) {
-  // Convert hex to RGB
-  const r = parseInt(hex.substring(0, 2), 16) / 255;
-  const g = parseInt(hex.substring(2, 4), 16) / 255;
-  const b = parseInt(hex.substring(4, 6), 16) / 255;
-
-  // Calculate relative luminance according to WCAG 2.1
-  const calLuminance = (c : number) => c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-  const L = 0.2126 * calLuminance(r) + 0.7152 * calLuminance(g) + 0.0722 * calLuminance(b);
-
-  // Return black or white based on the standard WCAG luminance threshold
-  return L > 0.179 ? BLACK : WHITE;
-}
-
-const routeInformation: {
-  [key: string]: {
-    route_short_name?: string,
-    route_long_name?: string,
-    route_color?: string,
-    route_text_color?: string,
-    route_url?: string
-  }
-} = {
-  "AW": {route_short_name: 'TfW Rail', route_long_name: "Transport for Wales", route_color: "ff0000"},
-  "CC": {route_long_name: "c2c", route_color: "b7007c"},
-  "CH": {route_long_name: "Chiltern Railways", route_color: "00bfff"},
-  "CS": {route_long_name: "Caledonian Sleeper", route_color: "1d2e35"},
-  "EM": {route_short_name: "EMR", route_long_name: "East Midlands Railway", route_color: "713563"},
-  "ES": {route_long_name: "Eurostar", route_color: "ffd700"},
-  "GC": {route_long_name: "Grand Central", route_color: "1d1d1b"},
-  "GN": {route_long_name: "Great Northern", route_color: "0099ff"},
-  "GR": {route_short_name: "LNER", route_long_name: "London North Eastern Railway", route_color: "ce0e2d"},
-  "GW": {route_short_name: "GWR", route_long_name: "Great Western Railway", route_color: "0a493e"},
-  "GX": {route_long_name: "Gatwick Express", route_color: "eb1e2d"},
-  "HT": {route_long_name: "Hull Trains", route_color: "de005c"},
-  "HX": {route_long_name: "Heathrow Express", route_color: "532e63"},
-  "IL": {route_long_name: "Island Line", route_color: "1e90ff"},
-  "LD": {route_long_name: "Lumo", route_color: "2b6ef5"},
-  "LE": {route_long_name: "Greater Anglia", route_color: "d70428"},
-  "LF": {route_long_name: "Lumo Stirling", route_color: "2b6ef5"},
-  "LM": {route_short_name: 'WMT', route_long_name: "West Midlands Trains"},
-  'LN': {route_short_name: 'LNR', route_long_name: 'London Northwestern Railway', route_color: '00bf6f', route_url: 'https://www.londonnorthwesternrailway.co.uk/'},
-  "LO": {route_short_name: "Overground", route_long_name: "London Overground", route_color: "ff7518"},
-  "LT": {route_short_name: "Underground", route_long_name: "London Underground", route_color: "000f9f"},
-  "ME": {route_long_name: "Merseyrail", route_color: "fff200"},
-  "NT": {route_long_name: "Northern", route_color: "0f0d78"},
-  "SE": {route_long_name: "Southeastern", route_color: "389cff"},
-  "SN": {route_long_name: "Southern", route_color: "8cc63e"},
-  "SR": {route_long_name: "ScotRail", route_color: "1e467d"},
-  "SW": {route_short_name: "SWR", route_long_name: "South Western Railway", route_color: "24398c"},
-  "SX": {route_long_name: "Stansted Express", route_color: "6b717a"},
-  "TL": {route_long_name: "Thameslink", route_color: "ff5aa4"},
-  "TP": {route_short_name: "TPE", route_long_name: "TransPennine Express", route_color: "09a4ec"},
-  "TW": {route_short_name: "Metro", route_long_name: "Tyne & Wear Metro"},
-  "VT": {route_short_name: 'Avanti', route_long_name: "Avanti West Coast", route_color: "004354"},
-  'WM': {route_short_name: 'WMR', route_long_name: 'West Midlands Railway', route_color: 'e07709', route_url: 'https://www.westmidlandsrailway.co.uk/'},
-  "XC": {route_long_name: "CrossCountry", route_color: "660f21"},
-  "XR": {route_long_name: "Elizabeth line", route_color: "9364cc", route_url: "https://tfl.gov.uk/elizabeth-line/route/elizabeth/"},
-  "BAK": {route_short_name: "Bakerloo", route_color: "a65a2a", route_url: "https://tfl.gov.uk/tube/route/bakerloo/"},
-  "DST": {route_short_name: "District", route_color: "007934", route_url: "https://tfl.gov.uk/tube/route/district/"},
-  "MET": {route_short_name: "Metropolitan", route_color: "870f54", route_url: "https://tfl.gov.uk/tube/route/metropolitan/"},
-  "LIB": {route_short_name: "Liberty", route_color: "61686B", route_url: "https://tfl.gov.uk/overground/route/liberty/"},
-  "LIO": {route_short_name: "Lioness", route_color: "FFA600", route_url: "https://tfl.gov.uk/overground/route/lioness/"},
-  "MIL": {route_short_name: "Mildmay", route_color: "006FE6", route_url: "https://tfl.gov.uk/overground/route/mildmay/"},
-  "SUF": {route_short_name: "Suffragette", route_color: "18A95D", route_url: "https://tfl.gov.uk/overground/route/suffragette/"},
-  "WEA": {route_short_name: "Weaver", route_color: "9B0058", route_url: "https://tfl.gov.uk/overground/route/weaver/"},
-  "WIN": {route_short_name: "Windrush", route_color: "DC241F", route_url: "https://tfl.gov.uk/overground/route/windrush/"},
-  "ME_Northern": {route_short_name: "Northern", route_color: "0266b2", route_url: "https://www.merseytravel.gov.uk/timetables/rail/northern-line/"},
-  "ME_Wirral": {route_short_name: "Wirral", route_color: "00a94f", route_url: "https://www.merseytravel.gov.uk/timetables/rail/wirral-line/"},
-  "GRN": {route_short_name: "Green", route_color: "32B457"},
-  "YEL": {route_short_name: "Yellow", route_color: "FCB828"},
 }
 
 /**
@@ -112,7 +37,7 @@ export class Schedule implements OverlayRecord {
     public readonly firstClassAvailable: boolean,
     public readonly reservationPossible: boolean
   ) {}
-  
+
   public get tripId(): string {
     return tripId(this.tuid, this.calendar);
   }
@@ -171,119 +96,83 @@ export class Schedule implements OverlayRecord {
   }
 
   /**
-   * We are trying to assign routes which are shown in mainstream journey
-   * planners and aligning with station information boards, using the following
-   * rules:
+   * The route this schedule runs on: the brand a passenger sees rather than
+   * anything the DTD feed names.
    *
-   * For London Underground, Tyne & Wear Metro, London Overground and 
-   * Merseyrail, the official line names are used.
-   * For West Midland Trains, show "WMR" or "LNR" depending on the where the
-   * service goes.
-   * For Greater Anglia, show "Stansted Express" if it runs between the airport
-   * and London, Stratford, Tottenham Hale or Seven Sisters
-   * Otherwise, use the short form of the operator brand name.
-   * 
+   * Most operators run one brand and this is their ATOC code. The ones that run
+   * several - London Underground, the Overground, Merseyrail, the Tyne & Wear
+   * Metro, West Midlands Trains and Greater Anglia's Stansted Express - are told
+   * apart by where the service goes, by the rules in `data/route.ts`.
+   *
+   * A route id is worked out from the schedule rather than handed out in the
+   * order schedules arrive, so it is the same id in every build and can be
+   * referred to from outside the feed.
+   *
    * TODO: If it is a bus service and the actual route number is available in the
    * "headcode" field, use it.
    */
   private get bareRouteId(): string {
-    const stopAtCallback = this.stopAt.bind(this);
-    
-    if (this.operator === 'LM') {
-      const lnrTermini = ['EUS', 'WFJ', 'TRI', 'BLY', 'MKC', 'NMP', 'SAA', 'BDM', 'LIV', 'CRE'];
-      if (lnrTermini.includes(this.origin) || lnrTermini.includes(this.destination)) {
-        return 'LN'; // London Northwestern Railway
-      }
-      return 'WM'; // West Midlands railway
-    }
-    
-    if (this.operator === 'LE' && [this.origin, this.destination].includes('SSD')) {
-      if (['LST', 'SRA', 'SVS', 'TOM'].some(stopAtCallback)) {
-        return 'SX';
-      }
+    const rules = lineRulesByOperator.get(this.operator);
+
+    if (rules === undefined) {
+      return this.operator;
     }
 
-    if (this.operator === 'LO') {
-      if (['LST', 'HAC', 'SKW', 'EDR', 'ENF', 'CHN', 'WST', 'CHI'].some(stopAtCallback)) {
-        return 'WEA';
-      }
-      // some Suffragette line services run through to Willesden Junction
-      if (['HRY', 'WMW', 'LER', 'BKG'].some(stopAtCallback)) {
-        return 'SUF';
-      }
-      if (['RMF', 'UPM'].some(stopAtCallback)) {
-        return 'LIB';
-      }
-      // I am considering Stratford - Watford through-running services to be Lioness line here, however services terminating at Willesden Junction are not.
-      if (['SBP', 'HRW', 'WFH', 'WFJ'].some(stopAtCallback)) {
-        return 'LIO';
-      }
-      if (['KPA', 'SPB', 'RMD', 'SAT', 'HDH', 'CMD', 'HKC', 'SRA'].some(stopAtCallback)) {
-        return 'MIL';
-      }
-      if (['DLJ', 'SDC', 'ZCW', 'SQE', 'NXG', 'NWX', 'SYD', 'WCY', 'CYP'].some(stopAtCallback)) {
-        return 'WIN';
-      }
-      if (['EUS', 'KBN', 'QPW'].some(stopAtCallback)) {
-        return 'LIO';
-      }
-    }
-    
-    if (this.operator === 'ME') {
-      if (['HNX', 'LPY', 'SDL', 'BAH', 'HLR', 'SOP', 'KKD', 'WAO', 'MAG', 'OMS', 'RIL', 'KIR', 'HBL', 'AIN'].some(stopAtCallback)) {
-        return 'ME_Northern';
-      }
-      if (['BKQ', 'NBN', 'BID', 'WKI', 'RFY', 'PSL', 'HOO', 'ELP', 'CTR'].some(stopAtCallback)) {
-        return 'ME_Wirral';
-      }
-    }
-    
-    if (this.operator === 'LT') {
-      if (['AMR', 'ZCM', 'RIC', 'ZMP', 'HOH', 'ZBS'].some(stopAtCallback)) {
-        return 'MET';
-      }
-      if (['RMD', 'GUN', 'ZTU'].some(stopAtCallback)) {
-        return 'DST';
-      }
-      if (['QPW', 'SBP', 'HRW'].some(stopAtCallback)) {
-        return 'BAK';
-      }
-    }
-    
-    if (this.operator === 'TW') {
-      if (['APN', 'FEG', 'REG', 'SUN'].some(stopAtCallback)) {
-        return 'GRN';
-      }
-      // I can't see any Yellow line service appearing in the National Rail timetable
-    }
-    
-    return this.operator;
+    // Built here rather than per rule: a service calls at a few dozen stations
+    // and a line is recognised by asking about a few dozen more.
+    const calls = new Set(this.stopTimes.map(stopTime => stopTime.stop_id));
+    const matches = (rule: LineRule) =>
+      (rule.between === undefined || rule.between.includes(this.origin) || rule.between.includes(this.destination))
+      && (rule.calls === undefined || rule.calls.some(crs => calls.has(crs)));
+
+    return rules.find(matches)?.line ?? this.operator;
   }
-  
-  public get routeId() : string {
-    return this.mode === RouteType.Bus ? `${this.bareRouteId}_BUS` : this.mode === RouteType.ReplacementBus ? `${this.bareRouteId}_RRB` : this.bareRouteId;
+
+  /**
+   * A bus does not run on the line its operator's trains do, so it is a route
+   * of its own. Replacement buses are separated from scheduled ones because a
+   * passenger reads them differently: one is the timetable, the other is what
+   * happens when the timetable fails.
+   */
+  public get routeId(): string {
+    switch (this.mode) {
+      case RouteType.Bus: return `${this.bareRouteId}_BUS`;
+      case RouteType.ReplacementBus: return `${this.bareRouteId}_RRB`;
+      default: return this.bareRouteId;
+    }
   }
 
   /**
    * Convert to GTFS Route.
+   *
+   * GTFS asks for a short name, a long name or both. The brand supplies what it
+   * has; an operator with no brand entry falls back to the name its agency
+   * record carries, as a long name, because an agency is named in full. The id
+   * itself is the last resort, for an operator this build has never heard of.
    */
   public toRoute(): Route {
-    const routeData = routeInformation[this.bareRouteId];
-    const agencyName = agencies.find(agency => agency.agency_id === this.operator)?.agency_name;
-    const routeColor = routeData?.route_color;
-    
+    const branding = routeBranding.get(this.bareRouteId);
+    const agency = agencyIndex.get(this.operator);
+    const longName = branding?.route_long_name
+      ?? (branding?.route_short_name === undefined ? agency?.agency_name : undefined);
+    const shortName = branding?.route_short_name
+      ?? (longName === undefined ? this.bareRouteId : undefined);
+    const color = branding?.route_color;
+
     return {
       route_id: this.routeId,
-      agency_id: agencies.some(agency => agency.agency_id === this.operator) ? this.operator : 'ZZ',
-      route_short_name: routeData?.route_short_name 
-          ?? (routeData?.route_long_name === undefined && agencyName === undefined ? this.bareRouteId : undefined),
-      route_long_name: routeData?.route_long_name
-          ?? (routeData?.route_short_name === undefined ? agencyName : undefined),
+      agency_id: agency?.agency_id ?? "ZZ",
+      route_short_name: shortName ?? null,
+      route_long_name: longName ?? null,
       route_type: this.mode,
-      route_text_color: routeColor === undefined ? undefined : getAccessibleTextColor(routeColor),
-      route_color: routeData?.route_color,
-      route_url: routeData?.route_url,
-      route_desc: undefined,
+      route_text_color: color === undefined ? null : accessibleTextColor(color),
+      route_color: color ?? null,
+      route_url: branding?.route_url ?? null,
+      // What the DTD says about a train - its class and whether it can be
+      // reserved - is a property of the train, not of the line it runs on.
+      // Flattening it onto the route made trips sharing a route disagree about
+      // their own description, so it is left out.
+      route_desc: null
     };
   }
 

--- a/libs/gtfs/src/transform/Noc.ts
+++ b/libs/gtfs/src/transform/Noc.ts
@@ -27,8 +27,9 @@ export function toAgencyRow(agency: Agency): AgencyRow {
 /**
  * routes.txt as it is written.
  *
- * `route_short_name` and `route_long_name` keep the bare ATOC code: they are
- * text for a passenger to read, not a reference to the agency.
+ * Only `agency_id` takes the NOC form. `route_id` is the brand's own id and the
+ * names are text for a passenger to read, so neither is a reference to an
+ * agency and neither is composed here.
  */
 export function toRouteRow(route: Route): RouteRow {
   return {...route, agency_id: agencyId(route.agency_id)};


### PR DESCRIPTION
Follow-up to #153, which is merged. Three commits, readable separately. Nothing published changes: the mini golden is untouched and the full feed builds identically.

## Move the route branding into data

The branding table and the six operators' station lists move from `Schedule` to
`libs/gtfs/src/data/route.ts`, alongside `agency.ts` and `station-coordinates.ts`.
They are data, and they are what needs editing when a brand changes.

The nested conditionals that recover a line from a service's calls become one ordered
`lineRules` table - operator, line, `between`, `calls` - so West Midlands Trains' terminus
rule and the Stansted Express's rule are written in the same shape as the Overground and
Underground ones. First match still wins.

`Schedule` keeps the lookup: one `agencyIndex` lookup instead of walking the agency array
twice per schedule, and the set of calls built once for the five operators that have rules
instead of scanning the stop times per station code.

Also here: the optional fields of `Route` go back to `null` as everywhere else in the feed
(the CSV writer treats `null` and `undefined` identically, so nothing published moves); the
stale `toRouteRow` comment is corrected; and the comments explaining why a route id is
stable are restored, along with an honest note on `chooseRoutes` about the mode collision
below.

## Pin what an unknown ATOC code does

An earlier version of this branch collapsed an ATOC code with no agency behind it into the
catch-all `ZZ` operator. @miklcct pointed out that the existing behaviour is deliberate and
better: each unknown operator gets a route of its own, and that route keeps its id when the
agency list catches up - `LF` ran before the software knew about Lumo (West Coast).
Collapsing them would put unrelated operators on one route and move every id later. He is
right; the line is back exactly as #153 wrote it.

What is left is a test pinning the behaviour, so it is stated somewhere rather than
inferred, and a changeset paragraph saying what a consumer sees. It also drops the
`agencies` import, unused since #153 replaced the check that read it.

## Review changes

Both points from @miklcct's review, in the third commit:

- The `accessibleTextColor` docblock no longer argues from what the spec says the field
  defaults to. The reason to write `route_text_color` on every route that has a colour is
  that a consumer choosing for itself cannot know half the palette is dark enough for black
  text to disappear into.
- The Underground test used `["RIC", "ZTU"]`, a journey no train makes. Rickmansworth to
  Baker Street and Richmond to Turnham Green tell the same two lines apart and are real; the
  Overground case, which is a service that runs, still covers first-match-wins.

## Tests

`Schedule.spec.ts` gains eleven cases over the rule engine this rewrites - single-brand
operator, line matching, first-rule-wins, the LM and LE special cases, bus and replacement
bus, direction independence - and the route fields, including text colour on a dark and a
light colour. `ScheduleBuilder.spec.ts` gains one for the ATOC behaviour. 462 tests pass.

## Performance

Measured on the full feed rather than claimed. End to end it is noise: 52.5s and 50.3s
after, 53.2s and 51.4s before, when two runs of the same build differ by more. Replaying
the same 276k schedules through `routeId` and `toRoute()` alone, it is ~93ms against
~110-130ms - 20-35ms of a 52 second build.

Worth recording why that number is not better: the first version of this memoized
`bareRouteId`, which made the same loop **60% slower** (~207ms). `memoized-class-decorator`
builds a per-instance cache and a string key per call, which costs more than recomputing a
getter that is usually one `Map.get` returning `undefined`. It earns its place on
`ScheduleCalendar.id`; it does not here, and it is gone.

## Changeset

#153 landed without one, so `.changeset/branded-routes.md` covers the route work as a
whole - including the breaking library changes (`RouteID` is a string, `Route`'s optional
fields are `null`, `Schedule.toTrip` lost an argument). It names `@gb-transit/gtfs` as well
as `dtd2mysql`, which every previous changeset here names alone; drop that line if the
app-only convention is deliberate.

## Not addressed: an operator running two modes

Answering @miklcct's question with the feed rather than a guess. Every BS/BX pair in
`RJTTF918`, by operator and mode:

| operator | rail | ferry |
|---|---|---|
| SW | 30,305 | 326 |
| AW | 20,576 | 109 |
| GW | 20,962 | 41 |
| VT | 4,012 | 106 |
| LE | 17,323 | 24 |
| SR | 16,916 | 11 |

Tyne & Wear has the same shape from a different direction: 1,024 subway and 208 rail.

Only `Bus` and `ReplacementBus` take an id of their own, so each of those pairs shares one
route id and the last schedule processed decides `route_type`. This is live, not
hypothetical: built from this branch, all six of those routes come out `route_type=2`, so
every one of the ~617 ship schedules is published on a route that calls itself a train.
`QC`, ferry-only, is correctly `4`.

Suffixing every non-rail mode would fix it but would change the Underground and Metro line
ids, which are fine as they are. A version that keeps ids stable: let each brand declare
its own mode in `data/route.ts`, and suffix only a schedule whose mode differs from what
its brand declares - `SW` stays `SW`, `BAK` stays `BAK`, and the Isle of Wight ships become
`SW_SHIP`, an id that does not exist today. Left out of this PR because it is a design
decision, not a tidy-up.

Two smaller things this made visible, also left alone: the `LM` branding entry can never be
reached, because the catch-all `{operator: "LM", line: "WM"}` rule always matches first, and
`YEL` has no rule by design. A test asserting every entry in the table is reachable would
have caught both.