### PR TITLE
Do not shift trains running in the repeated hour of the autumn clock change

### DIFF
--- a/.changeset/dst-repeated-hour.md
+++ b/.changeset/dst-repeated-hour.md
@@ -13,13 +13,14 @@ change, and wrong for one that runs through it: an 01:05 GMT departure is 26:05 
 service day, and telling it as 25:05 puts it alongside the train that already ran an hour earlier.
 
 The London Overground Windrush line is the only service in Great Britain that runs through the
-change, and it covers the repeated hour with short term plan schedules dated to that Sunday alone -
-four in each direction between Highbury & Islington and New Cross Gate. A schedule of that shape -
-operator `LO`, on the Windrush line, not permanent, departing between 01:00 and 01:59, and whose own
-record is dated to the last Sunday of October and nothing else - is now left where that record puts
-it. The standard schedules cover the first pass and are shifted as before. The count is logged when
-it is not zero, because the rule is expected to stop matching if the operator changes how it
-publishes these.
+change, and it covers the repeated hour with new short term plan schedules dated to that Sunday
+alone - four in each direction between Highbury & Islington and New Cross Gate. A schedule of that
+shape - operator `LO`, on the Windrush line, a new schedule rather than an overlay, departing
+between 01:00 and 01:59, and whose own record is dated to the last Sunday of October and nothing
+else - is now left where that record puts it. The standard schedules cover the first pass and are
+shifted as before, as is an overlay on that Sunday, which is how the departure already in the
+timetable gets retimed. The count is logged when it is not zero, because the rule is expected to
+stop matching if the operator changes how it publishes these.
 
 `Association.apply` now asks whether the shift will move the schedule of `asDated` rather than of
 `assoc`. `asDated` is the one that reaches the shift, and it carries the calendar `coupled` has just

--- a/.changeset/dst-repeated-hour.md
+++ b/.changeset/dst-repeated-hour.md
@@ -1,0 +1,25 @@
+---
+"@gb-transit/gtfs": minor
+"dtd2mysql": patch
+"dtd2gtfs": patch
+---
+
+Keep the trains that run in the repeated hour of the autumn clock change on the day they run.
+
+On the last Sunday of October 01:00 to 01:59 happens twice, once in BST and again in GMT.
+`shiftLateNightServices` moves anything departing before 02:00 onto the previous service day, which
+reads every such departure as the first pass. That is right for a service day that ends before the
+change, and wrong for one that runs through it: an 01:05 GMT departure is 26:05 of the Saturday
+service day, and telling it as 25:05 puts it alongside the train that already ran an hour earlier.
+
+The London Overground night service is the only one in Great Britain that runs through the change,
+and it covers the repeated hour with short term plan schedules dated to that Sunday alone - four in
+each direction between Highbury & Islington and New Cross Gate, signalling IDs starting `9Z`. A
+schedule of that shape - operator `LO`, not permanent, departing between 01:00 and 01:59, and
+running on the last Sunday of October and no other day - is now left where its own record dates it.
+The standard schedules cover the first pass and are shifted as before.
+
+`ScheduleCalendar.runningDates()` is new: the dates a calendar actually runs, as a generator.
+`isEmpty` is now asking it whether there is a first one.
+
+Closes #165.

--- a/.changeset/dst-repeated-hour.md
+++ b/.changeset/dst-repeated-hour.md
@@ -1,5 +1,5 @@
 ---
-"@gb-transit/gtfs": minor
+"@gb-transit/gtfs": patch
 "dtd2mysql": patch
 "dtd2gtfs": patch
 ---
@@ -12,14 +12,15 @@ reads every such departure as the first pass. That is right for a service day th
 change, and wrong for one that runs through it: an 01:05 GMT departure is 26:05 of the Saturday
 service day, and telling it as 25:05 puts it alongside the train that already ran an hour earlier.
 
-The London Overground night service is the only one in Great Britain that runs through the change,
-and it covers the repeated hour with short term plan schedules dated to that Sunday alone - four in
-each direction between Highbury & Islington and New Cross Gate, signalling IDs starting `9Z`. A
-schedule of that shape - operator `LO`, not permanent, departing between 01:00 and 01:59, and
-running on the last Sunday of October and no other day - is now left where its own record dates it.
-The standard schedules cover the first pass and are shifted as before.
+The London Overground Windrush line is the only service in Great Britain that runs through the
+change, and it covers the repeated hour with short term plan schedules dated to that Sunday alone -
+four in each direction between Highbury & Islington and New Cross Gate. A schedule of that shape -
+operator `LO`, on the Windrush line, not permanent, departing between 01:00 and 01:59, and whose own
+record is dated to the last Sunday of October and nothing else - is now left where that record puts
+it. The standard schedules cover the first pass and are shifted as before. The count is logged when
+it is not zero, because the rule is expected to stop matching if the operator changes how it
+publishes these.
 
-`ScheduleCalendar.runningDates()` is new: the dates a calendar actually runs, as a generator.
-`isEmpty` is now asking it whether there is a first one.
-
-Closes #165.
+`Association.apply` now asks whether the shift will move the schedule of `asDated` rather than of
+`assoc`. `asDated` is the one that reaches the shift, and it carries the calendar `coupled` has just
+narrowed, which is what the answer now depends on.

--- a/libs/gtfs/src/model/Association.spec.ts
+++ b/libs/gtfs/src/model/Association.spec.ts
@@ -457,10 +457,9 @@ describe("Association", () => {
   });
 
   /**
-   * `dayShift` has to be asked of `asDated` rather than of `assoc`. Whether the shift moves a train
-   * now depends on its calendar, and `coupled` has just narrowed one: this portion's record spans two
-   * Sundays and is shifted, while the coupled days are the change day alone, which is not. Asking the
-   * wrong one leaves the base on the Saturday, the portion on the Sunday and no copy to close the day.
+   * The portion's record spans two Sundays and is shifted; the coupled days are the change day
+   * alone, which is not. Reading `assoc` leaves the base on the Saturday and the portion on the
+   * Sunday with no copy to close the day.
    */
   it("counts the day gap against the calendar the coupling leaves", () => {
     const base = schedule(1, "A", "2026-10-25", "2026-10-25", STP.Permanent, SUNDAY, [

--- a/libs/gtfs/src/model/Association.spec.ts
+++ b/libs/gtfs/src/model/Association.spec.ts
@@ -456,9 +456,36 @@ describe("Association", () => {
     expect(surviving[0].assocLocation).to.equal("HRH");
   });
 
+  /**
+   * `dayShift` has to be asked of `asDated` rather than of `assoc`. Whether the shift moves a train
+   * now depends on its calendar, and `coupled` has just narrowed one: this portion's record spans two
+   * Sundays and is shifted, while the coupled days are the change day alone, which is not. Asking the
+   * wrong one leaves the base on the Saturday, the portion on the Sunday and no copy to close the day.
+   */
+  it("counts the day gap against the calendar the coupling leaves", () => {
+    const base = schedule(1, "A", "2026-10-25", "2026-10-25", STP.Permanent, SUNDAY, [
+      stop(1, "HHY", "01:00"),
+      stop(2, "NXG", "01:20"),
+    ], "LO");
+
+    const assoc = schedule(2, "B", "2026-10-18", "2026-10-25", STP.New, SUNDAY, [
+      stop(1, "NXG", "01:20"),
+      stop(2, "SYD", "01:30"),
+    ], "LO");
+
+    const result = association(base, assoc, AssociationType.Split, "NXG")
+      .apply(base, assoc, idGenerator(), true)!;
+
+    expect(result.asDated.calendar.runsFrom.equals("20261025")).to.be.true;
+    expect(result.duplicated).to.not.equal(null);
+    expect(result.duplicated!.calendar.runsFrom.equals("20261024")).to.be.true;
+    expect(result.duplicated!.stopTimes[0].departure_time).to.equal("25:20:30");
+  });
+
 });
 
 const ALL_DAYS: Days = { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
+const SUNDAY: Days = { 0: 1, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
 const WEEKDAYS: Days = { 0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 0 };
 const DAY_AFTER_WEEKDAYS: Days = { 0: 0, 1: 0, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
 

--- a/libs/gtfs/src/model/Association.ts
+++ b/libs/gtfs/src/model/Association.ts
@@ -80,8 +80,8 @@ export class Association implements OverlayRecord {
     // needs no copy - the shift puts it on the base's day anyway - while a same day one whose base
     // leaves at 00:30 does, because the shift takes the base off the day they shared.
     //
-    // Asked of `asDated` rather than of `assoc`, because `asDated` is the one that reaches the shift
-    // and the answer depends on the calendar `coupled` has just narrowed.
+    // Asked of `asDated`, not `assoc`: it is the one that reaches the shift, and the answer depends
+    // on the calendar `coupled` has just narrowed.
     const dayGap = this.dayOffset - dayShift(asDated) + dayShift(base);
 
     // A copy closes exactly one day, so it is worth making for a gap of one and nothing else. A gap

--- a/libs/gtfs/src/model/Association.ts
+++ b/libs/gtfs/src/model/Association.ts
@@ -79,7 +79,10 @@ export class Association implements OverlayRecord {
     // and opens days it does not. A next day association whose associated portion leaves at 00:35
     // needs no copy - the shift puts it on the base's day anyway - while a same day one whose base
     // leaves at 00:30 does, because the shift takes the base off the day they shared.
-    const dayGap = this.dayOffset - dayShift(assoc) + dayShift(base);
+    //
+    // Asked of `asDated` rather than of `assoc`, because `asDated` is the one that reaches the shift
+    // and the answer depends on the calendar `coupled` has just narrowed.
+    const dayGap = this.dayOffset - dayShift(asDated) + dayShift(base);
 
     // A copy closes exactly one day, so it is worth making for a gap of one and nothing else. A gap
     // of -1 wants a copy on the day after, which would need a time before 00:00; a gap of 2 wants two
@@ -89,7 +92,7 @@ export class Association implements OverlayRecord {
     // And not where the associated schedule is itself late night: `shiftLateNightServices` is about
     // to move it onto the very day the copy would sit on, at the very times the copy would carry, so
     // the copy would be the same trip written out again. That is a gap of one this cannot close.
-    const duplicated = duplicateOvernight && dayGap === 1 && !isLateNight(assoc)
+    const duplicated = duplicateOvernight && dayGap === 1 && !isLateNight(asDated)
       // The base's day, at times past 24:00 - a train leaving Edinburgh at 04:30 reads as 28:30 the
       // day before, no use to anyone boarding it there, which is why it is a copy and not a move.
       ? asDated.copyToPreviousServiceDay(idGenerator.next().value)

--- a/libs/gtfs/src/model/ScheduleCalendar.ts
+++ b/libs/gtfs/src/model/ScheduleCalendar.ts
@@ -31,18 +31,24 @@ export class ScheduleCalendar {
   }
 
   /**
+   * Every date the calendar actually runs: inside the range, on a day the mask has and not excluded.
+   *
+   * A generator because most callers want to know whether there is a first one, or a second, rather
+   * than the whole list - a calendar can span a year.
+   */
+  public* runningDates(): Generator<Temporal.PlainDate> {
+    for (let date = this.runsFrom; compare(date, this.runsTo) <= 0; date = date.add({ days: 1 })) {
+      if (this.days[dayOfWeek(date)] && !this.excludeDays[toYYYYMMDD(date)]) {
+        yield date;
+      }
+    }
+  }
+
+  /**
    * Returns true if the calendar does not run on any days e.g. when the whole day range has been excluded
    */
   public get isEmpty(): boolean {
-    const start = this.runsFrom;
-    const end = this.runsTo;
-
-    for (let date = start; compare(date, end) <= 0; date = date.add({ days: 1 })) {
-      if (this.days[dayOfWeek(date)] && !this.excludeDays[toYYYYMMDD(date)]) {
-        return false;
-      }
-    }
-    return true;
+    return this.runningDates().next().done === true;
   }
 
   /**

--- a/libs/gtfs/src/model/ScheduleCalendar.ts
+++ b/libs/gtfs/src/model/ScheduleCalendar.ts
@@ -31,24 +31,18 @@ export class ScheduleCalendar {
   }
 
   /**
-   * Every date the calendar actually runs: inside the range, on a day the mask has and not excluded.
-   *
-   * A generator because most callers want to know whether there is a first one, or a second, rather
-   * than the whole list - a calendar can span a year.
-   */
-  public* runningDates(): Generator<Temporal.PlainDate> {
-    for (let date = this.runsFrom; compare(date, this.runsTo) <= 0; date = date.add({ days: 1 })) {
-      if (this.days[dayOfWeek(date)] && !this.excludeDays[toYYYYMMDD(date)]) {
-        yield date;
-      }
-    }
-  }
-
-  /**
    * Returns true if the calendar does not run on any days e.g. when the whole day range has been excluded
    */
   public get isEmpty(): boolean {
-    return this.runningDates().next().done === true;
+    const start = this.runsFrom;
+    const end = this.runsTo;
+
+    for (let date = start; compare(date, end) <= 0; date = date.add({ days: 1 })) {
+      if (this.days[dayOfWeek(date)] && !this.excludeDays[toYYYYMMDD(date)]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/libs/gtfs/src/transform/MergeSchedules.spec.ts
+++ b/libs/gtfs/src/transform/MergeSchedules.spec.ts
@@ -6,6 +6,7 @@ import {Days, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {PickupDropOffType, StopTime} from "../entity/StopTime";
 import {Schedule} from "../model/Schedule";
 import {RouteType} from "../entity/Route";
+import {AgencyID} from "../entity/Agency";
 
 describe("MergeSchedules", () => {
 
@@ -93,7 +94,8 @@ export function schedule(id: number,
                          to: string,
                          stp: STP = STP.Overlay,
                          days: Days = ALL_DAYS,
-                         stops: StopTime[] = []): Schedule {
+                         stops: StopTime[] = [],
+                         operator: AgencyID = "LN"): Schedule {
 
   return new Schedule(
     id,
@@ -107,7 +109,7 @@ export function schedule(id: number,
       {}
     ),
     RouteType.Rail,
-    "LN",
+    operator,
     stp,
     true,
     true

--- a/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
@@ -77,4 +77,92 @@ describe("ShiftLateNightServices", () => {
     expect(shifted.stopTimes[0].departure_time).to.equal("25:30:30");
   });
 
+  /**
+   * The extra hour the clocks give back in October, and the London Overground night service that
+   * runs through it. See `runsInTheRepeatedHour`.
+   */
+  describe("on the day the clocks go back", () => {
+    const SUNDAY: Days = { 0: 1, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
+
+    const overground = (id: number, from: string, to: string, time: string, stp = STP.New, days = SUNDAY) =>
+      schedule(id, "A", from, to, stp, days, [
+        stop(1, "HHY", time),
+        stop(2, "NXG", plusTenMinutes(time))
+      ], "LO");
+
+    it("leaves an Overground schedule dated to the change day alone", () => {
+      const [kept] = shiftLateNightServices([overground(1, "2026-10-25", "2026-10-25", "01:05")]);
+
+      expect(kept.calendar.runsFrom.equals("20261025")).to.be.true;
+      expect(kept.calendar.runsTo.equals("20261025")).to.be.true;
+      expect(kept.calendar.days[0]).to.equal(1);
+      expect(kept.stopTimes[0].departure_time).to.equal("01:05:30");
+    });
+
+    it("shifts the standard schedule that covers the first pass of the hour", () => {
+      const [shifted] = shiftLateNightServices([
+        overground(1, "2026-06-01", "2026-12-31", "01:05", STP.Permanent)
+      ]);
+
+      expect(shifted.calendar.runsFrom.equals("20260531")).to.be.true;
+      expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
+    });
+
+    it("shifts a schedule that runs on the change day and on other days too", () => {
+      const [shifted] = shiftLateNightServices([
+        overground(1, "2026-10-18", "2026-10-25", "01:05")
+      ]);
+
+      expect(shifted.calendar.runsFrom.equals("20261017")).to.be.true;
+      expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
+    });
+
+    it("shifts a schedule dated to a Sunday in October that is not the last one", () => {
+      const [shifted] = shiftLateNightServices([
+        overground(1, "2026-10-18", "2026-10-18", "01:05")
+      ]);
+
+      expect(shifted.calendar.runsFrom.equals("20261017")).to.be.true;
+    });
+
+    /**
+     * Only 01:00 to 01:59 happens twice. Midnight comes round once whatever the clocks do, so a
+     * 00:45 departure is the end of the Saturday service day as it is on any other night.
+     */
+    it("shifts a schedule departing before the repeated hour", () => {
+      const [shifted] = shiftLateNightServices([overground(1, "2026-10-25", "2026-10-25", "00:45")]);
+
+      expect(shifted.calendar.runsFrom.equals("20261024")).to.be.true;
+      expect(shifted.stopTimes[0].departure_time).to.equal("24:45:30");
+    });
+
+    it("shifts another operator's schedule dated to the change day", () => {
+      const [shifted] = shiftLateNightServices([
+        schedule(1, "A", "2026-10-25", "2026-10-25", STP.New, SUNDAY, [
+          stop(1, "VIC", "01:05"),
+          stop(2, "TBD", "01:15")
+        ])
+      ]);
+
+      expect(shifted.calendar.runsFrom.equals("20261024")).to.be.true;
+      expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
+    });
+
+    /**
+     * 2027's last Sunday is the 31st, so a rule reading "after the 24th" and one reading "no Sunday
+     * left in the month" only differ here.
+     */
+    it("recognises a change day that falls on the last day of the month", () => {
+      const [kept] = shiftLateNightServices([overground(1, "2027-10-31", "2027-10-31", "01:05")]);
+
+      expect(kept.calendar.runsFrom.equals("20271031")).to.be.true;
+    });
+  });
+
 });
+
+function plusTenMinutes(time: string): string {
+  const [hours, minutes] = time.split(":").map(Number);
+
+  return `${hours.toString().padStart(2, "0")}:${(minutes + 10).toString().padStart(2, "0")}`;
+}

--- a/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
@@ -106,6 +106,16 @@ describe("ShiftLateNightServices", () => {
       expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
     });
 
+    /** An overlay on that Sunday retimes the BST departure, so it is still the first pass. */
+    it("shifts an overlay dated to the change day", () => {
+      const [shifted] = shiftLateNightServices([
+        overground(1, "2026-10-25", "2026-10-25", "01:05", STP.Overlay)
+      ]);
+
+      expect(shifted.calendar.runsFrom.equals("20261024")).to.be.true;
+      expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
+    });
+
     it("shifts a schedule that runs on the change day and on other days too", () => {
       const [shifted] = shiftLateNightServices([
         overground(1, "2026-10-18", "2026-10-25", "01:05")

--- a/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
@@ -3,6 +3,7 @@ import {STP} from "../model/OverlayRecord";
 import {schedule} from "./MergeSchedules.spec";
 import {stop} from "./ApplyAssociations.spec";
 import {shiftLateNightServices} from "./ShiftLateNightServices";
+import {applyOverlays} from "./ApplyOverlays";
 import {Days} from "../model/ScheduleCalendar";
 
 describe("ShiftLateNightServices", () => {
@@ -123,6 +124,41 @@ describe("ShiftLateNightServices", () => {
       ]);
 
       expect(shifted.calendar.runsFrom.equals("20261017")).to.be.true;
+    });
+
+    /**
+     * `applyOverlays` narrows by adding exclude days and leaves the range alone, so what a schedule
+     * is left running is not what its record dates it to. A wide record whittled down to the change
+     * day by a higher priority overlay is not one the operator published for the repeated hour.
+     */
+    it("shifts a record the overlays have whittled down to the change day", () => {
+      const wide = overground(1, "2026-10-04", "2026-11-29", "01:05");
+      const index = applyOverlays([
+        wide,
+        overground(2, "2026-10-04", "2026-10-18", "01:05"),
+        overground(3, "2026-11-01", "2026-11-29", "01:05")
+      ]);
+
+      const narrowed = index["A"].find(s => s.id === 1)!;
+      const [shifted] = shiftLateNightServices([narrowed]);
+
+      expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
+    });
+
+    /**
+     * The evidence is about the Windrush night service. Another Overground line does not run through
+     * the change, so a one-off on it at that hour is an ordinary late night train.
+     */
+    it("shifts an Overground schedule on another line", () => {
+      const [shifted] = shiftLateNightServices([
+        schedule(1, "A", "2026-10-25", "2026-10-25", STP.New, SUNDAY, [
+          stop(1, "RMF", "01:05"),
+          stop(2, "UPM", "01:15")
+        ], "LO")
+      ]);
+
+      expect(shifted.calendar.runsFrom.equals("20261024")).to.be.true;
+      expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
     });
 
     /**

--- a/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.spec.ts
@@ -78,10 +78,7 @@ describe("ShiftLateNightServices", () => {
     expect(shifted.stopTimes[0].departure_time).to.equal("25:30:30");
   });
 
-  /**
-   * The extra hour the clocks give back in October, and the London Overground night service that
-   * runs through it. See `runsInTheRepeatedHour`.
-   */
+  /** See `runsInTheRepeatedHour`. */
   describe("on the day the clocks go back", () => {
     const SUNDAY: Days = { 0: 1, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
 
@@ -126,11 +123,7 @@ describe("ShiftLateNightServices", () => {
       expect(shifted.calendar.runsFrom.equals("20261017")).to.be.true;
     });
 
-    /**
-     * `applyOverlays` narrows by adding exclude days and leaves the range alone, so what a schedule
-     * is left running is not what its record dates it to. A wide record whittled down to the change
-     * day by a higher priority overlay is not one the operator published for the repeated hour.
-     */
+    /** Narrowed onto the change day by an overlay, not dated to it by the operator. */
     it("shifts a record the overlays have whittled down to the change day", () => {
       const wide = overground(1, "2026-10-04", "2026-11-29", "01:05");
       const index = applyOverlays([
@@ -145,10 +138,7 @@ describe("ShiftLateNightServices", () => {
       expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
     });
 
-    /**
-     * The evidence is about the Windrush night service. Another Overground line does not run through
-     * the change, so a one-off on it at that hour is an ordinary late night train.
-     */
+    /** No other Overground line runs through the change, so this is an ordinary late night train. */
     it("shifts an Overground schedule on another line", () => {
       const [shifted] = shiftLateNightServices([
         schedule(1, "A", "2026-10-25", "2026-10-25", STP.New, SUNDAY, [
@@ -161,10 +151,7 @@ describe("ShiftLateNightServices", () => {
       expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
     });
 
-    /**
-     * Only 01:00 to 01:59 happens twice. Midnight comes round once whatever the clocks do, so a
-     * 00:45 departure is the end of the Saturday service day as it is on any other night.
-     */
+    /** Only 01:00 to 01:59 repeats; midnight comes round once whatever the clocks do. */
     it("shifts a schedule departing before the repeated hour", () => {
       const [shifted] = shiftLateNightServices([overground(1, "2026-10-25", "2026-10-25", "00:45")]);
 
@@ -184,10 +171,7 @@ describe("ShiftLateNightServices", () => {
       expect(shifted.stopTimes[0].departure_time).to.equal("25:05:30");
     });
 
-    /**
-     * 2027's last Sunday is the 31st, so a rule reading "after the 24th" and one reading "no Sunday
-     * left in the month" only differ here.
-     */
+    /** 2027's change day is the 31st, where "after the 24th" and "no Sunday left" diverge. */
     it("recognises a change day that falls on the last day of the month", () => {
       const [kept] = shiftLateNightServices([overground(1, "2027-10-31", "2027-10-31", "01:05")]);
 

--- a/libs/gtfs/src/transform/ShiftLateNightServices.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.ts
@@ -73,7 +73,6 @@ function runsInTheRepeatedHour(schedule: Schedule): boolean {
     && departureHour(schedule) === 1
     && schedule.calendar.runsFrom.equals(schedule.calendar.runsTo)
     && isLastSundayOfOctober(schedule.calendar.runsFrom)
-    // last: recognising the line walks the calls
     && schedule.routeId === WINDRUSH;
 }
 

--- a/libs/gtfs/src/transform/ShiftLateNightServices.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.ts
@@ -11,28 +11,33 @@ import {dayOfWeek} from "../model/PlainDate";
  * a DST change happening inside a service day.
  *
  * Therefore, trains which depart before the change on changeover days should be recorded as on the
- * previous service day instead. The exception is a train running in the second pass of the hour the
- * autumn change repeats, which `runsInTheRepeatedHour` describes.
+ * previous service day instead, unless they run in the hour the autumn change repeats - see
+ * `runsInTheRepeatedHour`.
  *
  * Each schedule is replaced rather than joined by a second one, so the copy keeps the id the
  * original was handed and no caller needs to supply a new one.
  */
 export function shiftLateNightServices(schedules: Schedule[]): Schedule[] {
   const result: Schedule[] = [];
+  let exempt = 0;
 
   for (const schedule of schedules) {
-    // a schedule with no stop times has no departure to shift, and will be dropped before
-    // any trip is written
-    if (schedule.stopTimes.length === 0) {
-      result.push(schedule);
+    if (isLateNight(schedule)) {
+      result.push(schedule.copyToPreviousServiceDay());
       continue;
     }
 
-    if (isLateNight(schedule)) {
-      result.push(schedule.copyToPreviousServiceDay());
-    } else {
-      result.push(schedule);
+    result.push(schedule);
+
+    if (runsInTheRepeatedHour(schedule)) {
+      exempt++;
     }
+  }
+
+  // Once a year, and expected to stop matching whenever the operator changes how it publishes these,
+  // so it says so rather than leaving the answer to a diff of two feeds.
+  if (exempt > 0) {
+    console.log(`Keeping ${exempt} schedules in the repeated hour of the autumn clock change`);
   }
 
   return result;
@@ -48,43 +53,44 @@ export function isLateNight(schedule: Schedule): boolean {
 }
 
 const LONDON_OVERGROUND: AgencyID = "LO";
+const WINDRUSH = "WIN";
 
 /**
- * The trains that run in the second pass of an hour the clocks repeat, and so must not be moved.
+ * Whether this train runs in the second pass of the hour the autumn change repeats, and so stays on
+ * the day its own record dates it.
  *
- * On the last Sunday of October 01:00 to 01:59 happens twice, once in BST and again in GMT. The
- * shift reads a departure time as the first pass, which is right for a service day that ends before
- * the change, and wrong for one that runs straight through it: 01:05 GMT is 26:05 of the Saturday
- * service day, not 25:05, and telling it as 25:05 puts it alongside the train that already ran an
- * hour earlier.
+ * On the last Sunday of October 01:00 to 01:59 happens twice, in BST and again in GMT. The shift
+ * reads a departure as the first pass, which is right for a service day ending before the change and
+ * wrong for one running through it: 01:05 GMT is 26:05 of the Saturday service day, and telling it
+ * as 25:05 puts it alongside the train that already ran an hour earlier.
  *
- * Nothing in the CIF says which pass a schedule means, so it is recognised by the shape the operator
- * publishes it in. The London Overground night service is the only one in Great Britain that runs
- * through the change, and it covers the repeated hour with short term plan schedules dated to that
- * Sunday alone - four in each direction between Highbury & Islington and New Cross Gate. The
- * standard schedules run in the first pass and are shifted as usual.
+ * Nothing in the CIF says which pass a schedule means, so it is recognised by the shape London
+ * Overground publishes the Windrush night service in - the only one in Great Britain running through
+ * the change. It covers the repeated hour with short term plan schedules dated to that Sunday alone,
+ * four in each direction between Highbury & Islington and New Cross Gate; the standard schedules
+ * cover the first pass and are shifted as usual. Those schedules also carry signalling IDs starting
+ * `9Z`, which is not read here because the CIF headcode does not reach `Schedule` - see the TODO on
+ * `Schedule.bareRouteId`.
  *
- * Restricted to schedules departing between 01:00 and 01:59 because that is the repeated hour;
- * an 00:45 departure happens once whatever the clocks do.
+ * The dates are the record's own rather than the days it is left running: `applyOverlays` adds
+ * exclude days without moving the range, so a wide record whittled down to that Sunday by a
+ * higher-priority overlay is not one the operator dated to it.
+ *
+ * Ordered cheapest first - `routeId` walks the calls to recognise the line, so it is asked last.
  */
 function runsInTheRepeatedHour(schedule: Schedule): boolean {
-  if (schedule.operator !== LONDON_OVERGROUND || schedule.stp === STP.Permanent) {
-    return false;
-  }
-
-  if (departureHour(schedule) !== 1) {
-    return false;
-  }
-
-  const dates = schedule.calendar.runningDates();
-  const first = dates.next();
-
-  // the one day it runs, and no other, is the day the hour repeats
-  return !first.done
-    && dates.next().done === true
-    && isLastSundayOfOctober(first.value);
+  return schedule.stopTimes.length > 0
+    && schedule.operator === LONDON_OVERGROUND
+    && schedule.stp !== STP.Permanent
+    && departureHour(schedule) === 1
+    && schedule.calendar.runsFrom.equals(schedule.calendar.runsTo)
+    && isLastSundayOfOctober(schedule.calendar.runsFrom)
+    && schedule.routeId === WINDRUSH;
 }
 
+/**
+ * A Sunday in October with no Sunday left after it, which is the 31st in 2027 and the 25th in 2026.
+ */
 function isLastSundayOfOctober(date: Temporal.PlainDate): boolean {
   return date.month === 10
     && dayOfWeek(date) === 0

--- a/libs/gtfs/src/transform/ShiftLateNightServices.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.ts
@@ -34,8 +34,7 @@ export function shiftLateNightServices(schedules: Schedule[]): Schedule[] {
     }
   }
 
-  // Once a year, and expected to stop matching whenever the operator changes how it publishes these,
-  // so it says so rather than leaving the answer to a diff of two feeds.
+  // fires once a year, and stops matching if the operator changes how it publishes these
   if (exempt > 0) {
     console.log(`Keeping ${exempt} schedules in the repeated hour of the autumn clock change`);
   }
@@ -56,27 +55,16 @@ const LONDON_OVERGROUND: AgencyID = "LO";
 const WINDRUSH = "WIN";
 
 /**
- * Whether this train runs in the second pass of the hour the autumn change repeats, and so stays on
- * the day its own record dates it.
+ * Whether this train runs in the second pass of the hour the clocks repeat, which the shift would
+ * publish an hour before it happens.
  *
- * On the last Sunday of October 01:00 to 01:59 happens twice, in BST and again in GMT. The shift
- * reads a departure as the first pass, which is right for a service day ending before the change and
- * wrong for one running through it: 01:05 GMT is 26:05 of the Saturday service day, and telling it
- * as 25:05 puts it alongside the train that already ran an hour earlier.
+ * The CIF does not say which pass a schedule means, so it is taken from the shape London Overground
+ * publishes the Windrush night service in: STP schedules dated to that Sunday alone. The 9Z
+ * signalling IDs #165 names would say it directly, but the headcode does not reach `Schedule`.
  *
- * Nothing in the CIF says which pass a schedule means, so it is recognised by the shape London
- * Overground publishes the Windrush night service in - the only one in Great Britain running through
- * the change. It covers the repeated hour with short term plan schedules dated to that Sunday alone,
- * four in each direction between Highbury & Islington and New Cross Gate; the standard schedules
- * cover the first pass and are shifted as usual. Those schedules also carry signalling IDs starting
- * `9Z`, which is not read here because the CIF headcode does not reach `Schedule` - see the TODO on
- * `Schedule.bareRouteId`.
- *
- * The dates are the record's own rather than the days it is left running: `applyOverlays` adds
- * exclude days without moving the range, so a wide record whittled down to that Sunday by a
- * higher-priority overlay is not one the operator dated to it.
- *
- * Ordered cheapest first - `routeId` walks the calls to recognise the line, so it is asked last.
+ * The dates are the record's own, not the days it is left running - `applyOverlays` excludes days
+ * without moving the range, so a wide record can be narrowed onto that Sunday without being dated
+ * to it.
  */
 function runsInTheRepeatedHour(schedule: Schedule): boolean {
   return schedule.stopTimes.length > 0
@@ -85,12 +73,11 @@ function runsInTheRepeatedHour(schedule: Schedule): boolean {
     && departureHour(schedule) === 1
     && schedule.calendar.runsFrom.equals(schedule.calendar.runsTo)
     && isLastSundayOfOctober(schedule.calendar.runsFrom)
+    // last: recognising the line walks the calls
     && schedule.routeId === WINDRUSH;
 }
 
-/**
- * A Sunday in October with no Sunday left after it, which is the 31st in 2027 and the 25th in 2026.
- */
+/** A Sunday with no Sunday left after it: the 25th in 2026, the 31st in 2027. */
 function isLastSundayOfOctober(date: Temporal.PlainDate): boolean {
   return date.month === 10
     && dayOfWeek(date) === 0

--- a/libs/gtfs/src/transform/ShiftLateNightServices.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.ts
@@ -59,8 +59,12 @@ const WINDRUSH = "WIN";
  * publish an hour before it happens.
  *
  * The CIF does not say which pass a schedule means, so it is taken from the shape London Overground
- * publishes the Windrush night service in: STP schedules dated to that Sunday alone. The 9Z
+ * publishes the Windrush night service in: new schedules dated to that Sunday alone. The 9Z
  * signalling IDs #165 names would say it directly, but the headcode does not reach `Schedule`.
+ *
+ * New rather than any short term plan record, because an overlay dated to that Sunday is how the
+ * BST departure already in the timetable gets retimed by a minute or two. That train is the first
+ * pass and still moves back a day.
  *
  * The dates are the record's own, not the days it is left running - `applyOverlays` excludes days
  * without moving the range, so a wide record can be narrowed onto that Sunday without being dated
@@ -69,7 +73,7 @@ const WINDRUSH = "WIN";
 function runsInTheRepeatedHour(schedule: Schedule): boolean {
   return schedule.stopTimes.length > 0
     && schedule.operator === LONDON_OVERGROUND
-    && schedule.stp !== STP.Permanent
+    && schedule.stp === STP.New
     && departureHour(schedule) === 1
     && schedule.calendar.runsFrom.equals(schedule.calendar.runsTo)
     && isLastSundayOfOctober(schedule.calendar.runsFrom)

--- a/libs/gtfs/src/transform/ShiftLateNightServices.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.ts
@@ -1,4 +1,7 @@
 import {Schedule} from "../model/Schedule";
+import {STP} from "../model/OverlayRecord";
+import {AgencyID} from "../entity/Agency";
+import {dayOfWeek} from "../model/PlainDate";
 
 /**
  * Loop through every schedule and replace any early morning services with a copy on the previous day.
@@ -8,7 +11,8 @@ import {Schedule} from "../model/Schedule";
  * a DST change happening inside a service day.
  *
  * Therefore, trains which depart before the change on changeover days should be recorded as on the
- * previous service day instead.
+ * previous service day instead. The exception is a train running in the second pass of the hour the
+ * autumn change repeats, which `runsInTheRepeatedHour` describes.
  *
  * Each schedule is replaced rather than joined by a second one, so the copy keeps the id the
  * original was handed and no caller needs to supply a new one.
@@ -39,5 +43,54 @@ export function shiftLateNightServices(schedules: Schedule[]): Schedule[] {
  */
 export function isLateNight(schedule: Schedule): boolean {
   return schedule.stopTimes.length > 0
-    && parseInt(schedule.stopTimes[0].departure_time.substring(0, 2), 10) <= 1;
+    && departureHour(schedule) <= 1
+    && !runsInTheRepeatedHour(schedule);
+}
+
+const LONDON_OVERGROUND: AgencyID = "LO";
+
+/**
+ * The trains that run in the second pass of an hour the clocks repeat, and so must not be moved.
+ *
+ * On the last Sunday of October 01:00 to 01:59 happens twice, once in BST and again in GMT. The
+ * shift reads a departure time as the first pass, which is right for a service day that ends before
+ * the change, and wrong for one that runs straight through it: 01:05 GMT is 26:05 of the Saturday
+ * service day, not 25:05, and telling it as 25:05 puts it alongside the train that already ran an
+ * hour earlier.
+ *
+ * Nothing in the CIF says which pass a schedule means, so it is recognised by the shape the operator
+ * publishes it in. The London Overground night service is the only one in Great Britain that runs
+ * through the change, and it covers the repeated hour with short term plan schedules dated to that
+ * Sunday alone - four in each direction between Highbury & Islington and New Cross Gate. The
+ * standard schedules run in the first pass and are shifted as usual.
+ *
+ * Restricted to schedules departing between 01:00 and 01:59 because that is the repeated hour;
+ * an 00:45 departure happens once whatever the clocks do.
+ */
+function runsInTheRepeatedHour(schedule: Schedule): boolean {
+  if (schedule.operator !== LONDON_OVERGROUND || schedule.stp === STP.Permanent) {
+    return false;
+  }
+
+  if (departureHour(schedule) !== 1) {
+    return false;
+  }
+
+  const dates = schedule.calendar.runningDates();
+  const first = dates.next();
+
+  // the one day it runs, and no other, is the day the hour repeats
+  return !first.done
+    && dates.next().done === true
+    && isLastSundayOfOctober(first.value);
+}
+
+function isLastSundayOfOctober(date: Temporal.PlainDate): boolean {
+  return date.month === 10
+    && dayOfWeek(date) === 0
+    && date.day + 7 > date.daysInMonth;
+}
+
+function departureHour(schedule: Schedule): number {
+  return parseInt(schedule.stopTimes[0].departure_time.substring(0, 2), 10);
 }


### PR DESCRIPTION
Closes #165.

## Problem

On the last Sunday of October the clocks go back and 01:00–01:59 occurs twice, in BST then GMT.
`shiftLateNightServices` moves any departure before 02:00 onto the previous service day, which
treats every such departure as the first occurrence.

That is correct for a service day ending before the change. It is wrong for one running through it:
an 01:05 GMT departure is 26:05 of the Saturday service day, and publishing it as 25:05 places it
alongside the train that ran an hour earlier.

The spring change needs no handling — 01:00–02:00 is skipped, so an 01:05 schedule departs at 02:05
wall time, which 25:05 Saturday already describes correctly.

## Change

The CIF does not record which occurrence a schedule means, so it is inferred from how the operator
publishes it. Per #165, the Windrush line is the only GB service running through the change, and it
covers the second occurrence with new STP schedules dated to that Sunday alone — four per direction
between Highbury & Islington and New Cross Gate.

A schedule is left on the day its record dates it when all of:

- operator is `LO`
- `routeId` is `WIN`
- STP indicator is New
- origin departure is 01:00–01:59
- its record is dated to the last Sunday of October and no other day

Everything else is unaffected, including the standard Windrush schedules, which cover the first
occurrence and are shifted as before.

Three details worth noting:

- **New, not any non-permanent record.** An overlay dated to that Sunday is how the BST departure
  already in the timetable gets retimed by a minute or two, and that train is the first occurrence.
  It is shifted like any other late night service.
- **The dates are the record's, not the days it is left running.** `applyOverlays` narrows a
  calendar by adding exclude days without moving `runsFrom`/`runsTo`, so a wide record can be
  reduced to the change day by a higher-priority overlay. That is not a schedule the operator
  published for the repeated hour, and reading the running dates would exempt it.
- **The `9Z` signalling IDs in the issue are not used.** The CIF headcode does not reach `Schedule`
  (see the TODO on `Schedule.bareRouteId`). `routeId` identifies the line instead.

The last-Sunday test is that no Sunday remains in the month, not that the date is after the 24th.
The two differ in 2027, when the change day is the 31st.

The exempt count is logged when non-zero, so it is visible from a build log whether the rule matched.

## `isLateNight` and `Association`

The check lives in `isLateNight` because `Association` uses it to predict the shift when computing
the day gap between a base and its portion; the two disagreeing would couple across a day.

This makes `isLateNight` depend on the calendar, where it previously depended only on departure
time. `Association.apply` computed `dayShift(assoc)` and then cloned the schedule with the narrower
calendar from `coupled` — and it is the clone that reaches the shift. An `LO` STP 01:05 portion
dated to two Sundays and coupled on one returned `true` for `assoc` and `false` for the clone,
leaving the base on the Saturday, the portion on the Sunday, and no copy to close the day.

`dayShift` and the duplicate condition now read `asDated`. Against the previous time-only predicate
this is a no-op, since the clone and the original always agreed.

## Testing

Eleven cases in `ShiftLateNightServices.spec.ts`, one in `Association.spec.ts`: the exempt schedule;
the standard schedule; an overlay on the change day; one running on the change day and others; one
on a non-final Sunday in October; a 00:45 departure; another operator; 2027's 31st; a record reduced
to the change day by overlays; another Overground line at the same hour; and the day gap counted
against the coupled calendar. The last four were each confirmed to fail with their fix backed out.

`yarn typecheck` clean, 554 tests pass. The mini golden is unchanged, so no baseline entry.

`ScheduleCalendar` is unmodified. The first commit added a `runningDates()` generator and rebuilt
`isEmpty` on it; the record-dates test does not need it, so both are reverted, which also avoids a
per-call generator allocation in `Association.apply`.
