### PR TITLE
Accept 25 backwards times with passing points, and say which they are

### DIFF
--- a/.github/validator-baseline-passing-points.json
+++ b/.github/validator-baseline-passing-points.json
@@ -4,7 +4,7 @@
     "why": "B10: a stop with no coordinate that something references is published at 0,0 and named in a warning, rather than at a plausible centroid that would hide it. QBN/QBS are the two. Goes to 0 when D3 or D7 gives them coordinates."
   },
   "stop_time_with_arrival_before_previous_departure_time": {
-    "max": 24,
-    "why": "The 1 that .github/validator-baseline.json accepts, plus 23 the passing points bring with them. A call publishes its public time and a passing point has only its working time, and the CIF's two clocks disagree: C17075 passes SELYOAK at 2116H and calls at UNVRSYB with a working arrival of 2117H and a public one of 2115, so the pass reads as later than the call after it. Correcting it would mean inventing a time for one of them. Recount after a refresh changes how many services are timed that way."
+    "max": 25,
+    "why": "The 1 that .github/validator-baseline.json accepts, plus 24 the passing points bring with them. A call publishes its public time and a passing point has only its working time, and the CIF's two clocks disagree: C17075 passes SELYOAK at 2116H and calls at UNVRSYB with a working arrival of 2117H and a public one of 2115, so the pass reads as later than the call after it. Correcting it would mean inventing a time for one of them. Five schedules account for all 24 - C02034, C02035, C04552, C17075 and C31860 - and each dated trip they run counts once, so a refresh that moves their calendars moves this number with nothing having gone wrong. Enumerate before raising it: what makes a recount safe is that every occurrence is still a pass reading later than the call after it."
   }
 }

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -224,6 +224,7 @@ jobs:
           ls -la gtfs.zip gtfs-passing-points.zip
 
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: feed
           path: |

--- a/apps/dtd2gtfs/fixtures/BASELINE.md
+++ b/apps/dtd2gtfs/fixtures/BASELINE.md
@@ -13,6 +13,35 @@ before committing it** - that is the whole value of the file being text.
 
 ---
 
+## The passing points feed accepts 25 backwards times, not 24
+
+**The nightly has failed every night since #152 landed.**
+`.github/validator-baseline-passing-points.json` takes
+`stop_time_with_arrival_before_previous_departure_time` from 24 to **25**. No code changed under it:
+#152 merged at 21:04 on 4 September, after that morning's nightly, so the 5th was the first run to
+build the second feed at all. The gate has never passed, rather than having passed and broken. Runs
+`33956103396` and `34023683835` both report 25, and both stop before the release step - no feed has
+been published from either.
+
+Rebuilt from the 6 September refresh over the same 2026-09-06 to 2026-12-06 window and validated
+with the same 8.0.1 jar: **25**, with `point_near_origin` holding at 2 and no other error. The
+standard feed is unmoved at 1, so this is the passing points alone.
+
+Enumerated rather than counted. 24 of the 25 are a passing point followed by a call, which is the
+two-clocks disagreement the baseline already describes; the 25th is `Z03536`, the one the standard
+baseline accepts. Six schedules produce all of them - `C02034`, `C02035`, `C04552`, `C17075`,
+`C31860` and `Z03536` - and a schedule contributes one occurrence per dated trip it runs, which is
+why the total wanders without anything being wrong.
+
+Against the 22 measured on #160's branch, the 3 are `C31860`, which is new to the refresh and passes
+`BLAYDON` at `1646H` before calling at `GTSHDMC1` with a public arrival of `1646`, and two more
+dated trips of `C02034` on 8 and 29 November. Both are the same shape as the 22, so nothing here is
+a defect that appeared - it is the calendar under five schedules moving.
+
+Raised rather than given headroom. The number is a function of how many days those five run, so it
+will move again; the `why` now names them, so the next recount is a rebuild and a diff of that list
+rather than a rediscovery. A cap that is a known quantity is the whole value of the file.
+
 ## An overnight portion is published once, on its own day
 
 **#160, following #158.** A schedule that runs the day after its base was published twice: once told

--- a/scripts/check-validation.mjs
+++ b/scripts/check-validation.mjs
@@ -37,8 +37,50 @@ const unlisted = [...counted].filter(([code]) => !baseline.hasOwnProperty(code))
 const grown = [...counted].filter(([code, count]) => baseline[code] && count > baseline[code].max);
 const shrunk = Object.entries(baseline).filter(([code, {max}]) => (counted.get(code) ?? 0) < max);
 
+const shown = 20;
+
+const describe = sample => Object.entries(sample)
+  .filter(([, value]) => value !== null && value !== undefined)
+  .map(([field, value]) => `${field}=${value}`)
+  .join(" ");
+
+const schedules = samples => {
+  const counts = new Map();
+
+  for (const {tripId} of samples) {
+    const schedule = tripId.split("_")[0];
+    counts.set(schedule, (counts.get(schedule) ?? 0) + 1);
+  }
+
+  return [...counts]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([schedule, count]) => count > 1 ? `${schedule} (${count})` : schedule);
+};
+
+const detail = code => {
+  const {sampleNotices: samples, totalNotices: total} = errors.find(error => error.code === code);
+
+  if (samples.length > 0 && samples.every(sample => sample.tripId)) {
+    const named = schedules(samples);
+    console.log(`  ${named.length} schedule(s): ${named.join(", ")}`);
+  }
+
+  for (const sample of samples.slice(0, shown)) {
+    console.log(`  ${describe(sample)}`);
+  }
+
+  if (total > shown) {
+    console.log(`  ...and ${total - shown} more`);
+  }
+
+  if (total > samples.length) {
+    console.log(`  (the report holds ${samples.length} of the ${total})`);
+  }
+};
+
 for (const [code, count] of counted) {
   console.log(`${code} ${count}${baseline[code] ? ` (baseline ${baseline[code].max})` : ""}`);
+  detail(code);
 }
 
 for (const [code, count] of unlisted) {


### PR DESCRIPTION
The nightly has failed every night since #152 landed — runs [33956103396](https://github.com/planarnetwork/dtd2mysql/actions/runs/33956103396) and [34023683835](https://github.com/planarnetwork/dtd2mysql/actions/runs/34023683835), both `stop_time_with_arrival_before_previous_departure_time` 25 against a baseline of 24. #152 merged at 21:04 on 4 September, after that morning's nightly, so the 5th was the first run to build the second feed at all. The gate has never passed rather than having passed and broken, and both runs stop before the release step, so no feed has been published from either.

## What it is

Rebuilt from the 6 September refresh over the same 2026-09-06 to 2026-12-06 window and validated with the same 8.0.1 jar: **25**, with `point_near_origin` holding at 2 and no other error. The standard feed is unmoved at 1, so this is the passing points alone.

Enumerated rather than counted. 24 of the 25 are a passing point followed by a call — the CIF's two clocks disagreeing, which is what the baseline already describes — and the 25th is `Z03536`, the one the standard baseline accepts. Six schedules produce all of them:

```
6 schedule(s): C02034 (7), C02035 (13), C04552, C17075 (2), C31860, Z03536
```

Against the 22 measured on #160's branch, the three extra are `C31860`, new to the refresh, which passes `BLAYDON` at `1646H` before calling at `GTSHDMC1` with a public arrival of `1646`, and two more dated trips of `C02034` in November. Same shape as the rest — the calendar under five schedules moving, not a defect that appeared.

Raised rather than given headroom: a cap that is a known quantity is the point of the file. The `why` now names the five, so the next recount is a diff of that list rather than a rediscovery.

## Why it took a rebuild to answer that, and won't again

`check-validation.mjs` read `totalNotices` and discarded `sampleNotices`. The report holds every occurrence — it stops collecting at a thousand, and the accepted errors are 25 and 2 — so the count was the only thing standing between a failing log and the answer. It now names them, on a pass as well as a failure, so tonight's log diffs against last night's.

`upload-artifact` gets `if: always()`. Every step is downstream of the gate, so the run that most needs its report was exactly the run that discarded it. `check-validation.mjs` writes `validation.json` before it exits, so a failed gate still leaves the full report behind.

## Checking

- the real report against the new baseline: exit 0
- the same report against a forced 24: exit 1, with the occurrences still printed
- the field printer is generic over whatever a notice carries; the schedule grouping only applies when every sample has a `tripId`