### PR TITLE
Take Temporal from a polyfill and lower the engine floor to Node 22

### DIFF
--- a/.changeset/node-22-temporal-polyfill.md
+++ b/.changeset/node-22-temporal-polyfill.md
@@ -1,0 +1,34 @@
+---
+"@gb-transit/gtfs-schema": minor
+"@gb-transit/dtd-source": minor
+"@gb-transit/gtfs": minor
+"dtd2mysql": minor
+"@gb-transit/gtfs-loader": patch
+"@gb-transit/gtfs-output": patch
+"@gb-transit/naptan": patch
+"transxchange2gtfs": patch
+"gtfsmerge": patch
+"cif2gtfs": patch
+---
+
+Lower the engine floor from Node 26 to Node 22, with Temporal from `temporal-polyfill`.
+
+Node 26 was required for one reason: it is the first release to expose `Temporal` as a global,
+and the calendar is written against it. That put every package on a runtime that will not be LTS
+until October, for an API the rest of the code does not care about the provenance of.
+
+`temporal-polyfill` provides it, and hands over to the built-in global wherever there is one, so
+Node 26 runs exactly the implementation it ran before — the import resolves to the same object.
+Where `Temporal` was reached as a global it is now imported, which is the whole of the change to
+the date handling: the polyfill exports it as a namespace, so the declarations still read
+`Temporal.PlainDate`, and the pinned type surface has not moved.
+
+CI runs 22 and 26 rather than 26 alone. `lib` drops from `esnext` to `es2024` so that an API the
+floor does not have cannot be typed as though it did — which is also what proves the global is
+gone, since a missed call site no longer compiles.
+
+One thing was genuinely broken below Node 24 rather than merely unavailable. `FeedZip` reports
+the file and the line a CIF record failed to parse on by throwing from a `data` listener, and an
+error thrown there only reaches `finished()` from Node 24 onwards; on 22 it escaped as an uncaught
+exception and the stream never settled. It destroys the stream with that error instead, which
+reports the same thing on every version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['26']
+        # Both sides of the Temporal polyfill: 22 is the engine floor and has no
+        # Temporal of its own, so it runs the polyfill's implementation, while 26
+        # ships Temporal as a global and the polyfill defers to it. A date bug
+        # that only appears on one of them is otherwise invisible here.
+        version: ['22', '26']
       fail-fast: false
     steps:
       # Deep, because the baseline guard diffs against the branch point and a

--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ yarn install
 yarn test
 ```
 
-Node 26, as [`.nvmrc`](.nvmrc) pins it.
+Node 26 to develop on, as [`.nvmrc`](.nvmrc) pins it. What the packages themselves need is Node 22,
+which is what CI runs alongside 26: Temporal comes from
+[`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill), which defers to the built-in
+global wherever there is one, so both the polyfilled and the native path are exercised.
 
 [`apps/cif2gtfs/fixtures/mini`](apps/cif2gtfs/fixtures/mini) holds a small slice of a real feed and
 the GTFS it produces, committed as text. The test suite builds it and diffs, so a change in the

--- a/apps/cif2gtfs/README.md
+++ b/apps/cif2gtfs/README.md
@@ -15,8 +15,9 @@ yarn workspace cif2gtfs run start build --source RJTTF918.ZIP --out gtfs.zip
 
 ## Requirements
 
-Node.js 26 or later. Date handling uses the built-in `Temporal` API, which is only available as a
-global from Node 26 onwards.
+Node.js 22 or later. Date handling uses `Temporal`, through
+[`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill), which hands over to the
+built-in global on the versions that have one - Node 26 and later.
 
 ## Usage
 

--- a/apps/cif2gtfs/package.json
+++ b/apps/cif2gtfs/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/planarnetwork/dtd2mysql#readme",
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "@gb-transit/dtd-source": "workspace:^",

--- a/apps/dtd2mysql/README.md
+++ b/apps/dtd2mysql/README.md
@@ -10,8 +10,9 @@ At the moment only MySQL compatible databases are supported but it could be exte
 
 ## Requirements
 
-Node.js 26 or later. Date handling uses the built-in `Temporal` API, which is only available as a global
-from Node 26 onwards.
+Node.js 22 or later. Date handling uses `Temporal`, through
+[`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill), which hands over to the
+built-in global on the versions that have one - Node 26 and later.
 
 ## Download / Install
 

--- a/apps/dtd2mysql/package.json
+++ b/apps/dtd2mysql/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/planarnetwork/dtd2mysql#readme",
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "@gb-transit/dtd-schema": "workspace:^",
@@ -49,7 +49,8 @@
     "byline": "5.0.0",
     "memoized-class-decorator": "1.6.1",
     "mysql2": "3.23.1",
-    "proj4": "2.20.9"
+    "proj4": "2.20.9",
+    "temporal-polyfill": "1.0.4"
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.8",

--- a/apps/dtd2mysql/src/cli/CleanFaresCommand.ts
+++ b/apps/dtd2mysql/src/cli/CleanFaresCommand.ts
@@ -1,4 +1,5 @@
 
+import {Temporal} from "temporal-polyfill";
 import {CLICommand} from "./CLICommand";
 import {DatabaseConnection} from "../database/DatabaseConnection";
 

--- a/apps/dtd2mysql/src/source/MySqlTimetableSource.spec.ts
+++ b/apps/dtd2mysql/src/source/MySqlTimetableSource.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {DatabaseConnection} from "../database/DatabaseConnection";
 import {MySqlTimetableSource} from "./MySqlTimetableSource";
 import {Pool} from "mysql2";

--- a/apps/dtd2mysql/src/source/MySqlTimetableSource.ts
+++ b/apps/dtd2mysql/src/source/MySqlTimetableSource.ts
@@ -1,5 +1,6 @@
 
 import {Pool} from "mysql2";
+import {Temporal} from "temporal-polyfill";
 import {DatabaseConnection} from "../database/DatabaseConnection";
 import {
   Association,

--- a/apps/gtfsmerge/README.md
+++ b/apps/gtfsmerge/README.md
@@ -22,7 +22,7 @@ gtfsmerge merges multiple GTFS feeds into a single one.
 npm install -g gtfsmerge
 ```
 
-Requires [node 26](https://nodejs.org) or above. No `zip` binary is needed — the archive is written
+Requires [node 22](https://nodejs.org) or above. No `zip` binary is needed — the archive is written
 in process.
 
 ## Usage

--- a/apps/gtfsmerge/package.json
+++ b/apps/gtfsmerge/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/planarnetwork/dtd2mysql#readme",
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "@gb-transit/gtfs": "workspace:^",

--- a/apps/transxchange2gtfs/README.md
+++ b/apps/transxchange2gtfs/README.md
@@ -21,7 +21,7 @@ There are other [similar projects](https://github.com/search?q=transxchange+gtfs
 
 ## Installation
 
-Requires [node 26](https://nodejs.org) or above. No `zip` or `unzip` binary is needed — archives
+Requires [node 22](https://nodejs.org) or above. No `zip` or `unzip` binary is needed — archives
 are read and written in process, so this runs on Windows.
 
 transxchange2gtfs is a CLI tool that can be installed via NPM:

--- a/apps/transxchange2gtfs/package.json
+++ b/apps/transxchange2gtfs/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/planarnetwork/dtd2mysql#readme",
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "@gb-transit/gtfs": "workspace:^",

--- a/libs/dtd-source/README.md
+++ b/libs/dtd-source/README.md
@@ -69,8 +69,9 @@ Credentials are the ones issued by the RSP for the DTD feeds.
 
 ## Requirements
 
-Node.js 26 or later. Date handling uses the built-in `Temporal` API, which is only available as a
-global from Node 26 onwards.
+Node.js 22 or later. Date handling uses `Temporal`, through
+[`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill), which hands over to the
+built-in global on the versions that have one - Node 26 and later.
 
 ## Contributing
 

--- a/libs/dtd-source/package.json
+++ b/libs/dtd-source/package.json
@@ -31,7 +31,8 @@
     "@gb-transit/gtfs": "workspace:^",
     "adm-zip": "0.6.0",
     "byline": "5.0.0",
-    "ssh2": "1.17.0"
+    "ssh2": "1.17.0",
+    "temporal-polyfill": "1.0.4"
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.8",

--- a/libs/dtd-source/src/cif/CifFileSource.spec.ts
+++ b/libs/dtd-source/src/cif/CifFileSource.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect, beforeEach, afterEach} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {interchange} from "@gb-transit/gtfs";
 import AdmZip from "adm-zip";
 import * as fs from "node:fs";

--- a/libs/dtd-source/src/cif/CifFileSource.ts
+++ b/libs/dtd-source/src/cif/CifFileSource.ts
@@ -1,3 +1,4 @@
+import {Temporal} from "temporal-polyfill";
 import config from "@gb-transit/dtd-schema";
 import {FieldValue, MultiRecordFile, RecordAction, SingleRecordFile} from "@gb-transit/feed-parser";
 import {

--- a/libs/dtd-source/src/cif/FeedZip.ts
+++ b/libs/dtd-source/src/cif/FeedZip.ts
@@ -62,10 +62,16 @@ export class FeedZip {
       catch (err) {
         // Seven million lines in, "non-nullable field received null value" is
         // only useful with the line it came from attached.
-        throw new Error(
+        //
+        // Destroyed rather than thrown: an error thrown from a data listener
+        // only reaches finished() from Node 24 onwards. On 22 it escapes as an
+        // uncaught exception and the stream never settles, so the caller waits
+        // for a file that will never finish instead of being told which line
+        // it stopped on.
+        lines.destroy(new Error(
           `${path.basename(entry.entryName)} line ${number}: ${err instanceof Error ? err.message : err}\n  ${line}`,
           {cause: err}
-        );
+        ));
       }
     });
 

--- a/libs/gtfs-loader/package.json
+++ b/libs/gtfs-loader/package.json
@@ -42,7 +42,7 @@
     "journey planning"
   ],
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "@gb-transit/gtfs-schema": "workspace:^",

--- a/libs/gtfs-output/package.json
+++ b/libs/gtfs-output/package.json
@@ -26,7 +26,7 @@
     "build": "tsc -b"
   },
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "@gb-transit/gtfs": "workspace:^",

--- a/libs/gtfs-schema/README.md
+++ b/libs/gtfs-schema/README.md
@@ -8,7 +8,9 @@ npm install @gb-transit/gtfs-schema
 
 Types only, near enough: an interface for every entity a feed publishes, a `Row` type for every file
 it writes, three enums for the coded columns, and the two scalar modules the rest is expressed in.
-It depends on nothing.
+Its one dependency is [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill), which
+the date helpers are written against so that a runtime without a `Temporal` global still has one;
+`@gb-transit/gtfs-schema/scalars` does not reach it and depends on nothing at all.
 
 That is the point of it. [`@gb-transit/gtfs`](https://www.npmjs.com/package/@gb-transit/gtfs) holds
 the transit model, the schedule transforms and the build, and to do the DTD's coordinates it pulls

--- a/libs/gtfs-schema/package.json
+++ b/libs/gtfs-schema/package.json
@@ -46,9 +46,12 @@
     "test": "vitest run"
   },
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "devDependencies": {
     "typescript": "7.0.2"
+  },
+  "dependencies": {
+    "temporal-polyfill": "1.0.4"
   }
 }

--- a/libs/gtfs-schema/src/model/PlainDate.spec.ts
+++ b/libs/gtfs-schema/src/model/PlainDate.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from 'vitest';
+import {Temporal} from 'temporal-polyfill';
 import {compare, dayOfWeek, maxDate, minDate, toYYYYMMDD} from "./PlainDate.js";
 
 const date = (value: string) => Temporal.PlainDate.from(value);

--- a/libs/gtfs-schema/src/model/PlainDate.ts
+++ b/libs/gtfs-schema/src/model/PlainDate.ts
@@ -3,6 +3,8 @@
  * The Temporal.PlainDate operations this project needs that Temporal itself does not provide.
  */
 
+import { Temporal } from "temporal-polyfill";
+
 import type { DayOfWeek } from "./DayOfWeek.js";
 
 export type { DayOfWeek };

--- a/libs/gtfs-schema/src/scalars.ts
+++ b/libs/gtfs-schema/src/scalars.ts
@@ -2,9 +2,8 @@
  * The scalars, on their own, for a consumer that wants nothing else.
  *
  * `@gb-transit/gtfs-schema` itself is cheap to import, but its declarations reach `PlainDate`,
- * which is typed against the `Temporal` global. A project whose TypeScript predates Temporal, or
- * which type checks its dependencies rather than skipping them, cannot read those declarations -
- * and would be stopped by a file it has no use for.
+ * which is typed against Temporal and so pulls in `temporal-polyfill` - a whole calendar
+ * implementation that a project reading a feed has no use for.
  *
  * So `@gb-transit/gtfs-schema/scalars` is the narrow way in: a duration and a day of the week, from
  * two modules that import nothing. It is what @gb-transit/gtfs-loader uses, which is how a browser

--- a/libs/gtfs/README.md
+++ b/libs/gtfs/README.md
@@ -103,8 +103,9 @@ terms nobody can state.
 
 ## Requirements
 
-Node.js 26 or later. Date handling uses the built-in `Temporal` API, which is only available as a
-global from Node 26 onwards.
+Node.js 22 or later. Date handling uses `Temporal`, through
+[`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill), which hands over to the
+built-in global on the versions that have one - Node 26 and later.
 
 ## Contributing
 

--- a/libs/gtfs/package.json
+++ b/libs/gtfs/package.json
@@ -27,12 +27,13 @@
     "test": "vitest run"
   },
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "@gb-transit/gtfs-schema": "workspace:^",
     "memoized-class-decorator": "1.6.1",
-    "proj4": "2.20.9"
+    "proj4": "2.20.9",
+    "temporal-polyfill": "1.0.4"
   },
   "devDependencies": {
     "typescript": "7.0.2"

--- a/libs/gtfs/src/build/BuildContext.spec.ts
+++ b/libs/gtfs/src/build/BuildContext.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {buildContext, dateRange, option, parseRange} from "./BuildContext";
 
 describe("parseRange", () => {

--- a/libs/gtfs/src/build/BuildContext.ts
+++ b/libs/gtfs/src/build/BuildContext.ts
@@ -1,3 +1,5 @@
+import {Temporal} from "temporal-polyfill";
+
 /**
  * Everything about a build that is not the data: which day it is being built for,
  * and how far ahead it reaches.

--- a/libs/gtfs/src/build/BuildFeed.spec.ts
+++ b/libs/gtfs/src/build/BuildFeed.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {BuildFeed} from "./BuildFeed";
 import {BuildContext, parseRange} from "./BuildContext";
 import {Enricher} from "../enrich/Enricher";

--- a/libs/gtfs/src/build/ScheduleBuilder.ts
+++ b/libs/gtfs/src/build/ScheduleBuilder.ts
@@ -1,3 +1,4 @@
+import {Temporal} from "temporal-polyfill";
 import {IdGenerator, STP} from "../model/OverlayRecord";
 import {Schedule, tripId} from "../model/Schedule";
 import {PickupDropOffType, RouteType, StopTime} from "@gb-transit/gtfs-schema";

--- a/libs/gtfs/src/model/Association.spec.ts
+++ b/libs/gtfs/src/model/Association.spec.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'vitest';
+import {Temporal} from 'temporal-polyfill';
 import {Days, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {STP} from "../model/OverlayRecord";
 import {CRS, PickupDropOffType, StopTime} from "@gb-transit/gtfs-schema";

--- a/libs/gtfs/src/model/Schedule.spec.ts
+++ b/libs/gtfs/src/model/Schedule.spec.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'vitest';
+import {Temporal} from 'temporal-polyfill';
 import {STP} from "../model/OverlayRecord";
 import {Days, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {schedule} from "../transform/MergeSchedules.spec";

--- a/libs/gtfs/src/model/ScheduleCalendar.spec.ts
+++ b/libs/gtfs/src/model/ScheduleCalendar.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from 'vitest';
+import {Temporal} from 'temporal-polyfill';
 import {Days, ExcludeDays, OverlapType, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {ALL_DAYS} from "../transform/MergeSchedules.spec";
 import {dayOfWeek, toYYYYMMDD} from "@gb-transit/gtfs-schema";

--- a/libs/gtfs/src/model/ScheduleCalendar.ts
+++ b/libs/gtfs/src/model/ScheduleCalendar.ts
@@ -1,5 +1,6 @@
 
 import memoize from "memoized-class-decorator";
+import type {Temporal} from "temporal-polyfill";
 import {Calendar, CalendarDate, compare, dayOfWeek, maxDate, minDate, toYYYYMMDD} from "@gb-transit/gtfs-schema";
 
 export class ScheduleCalendar {

--- a/libs/gtfs/src/transform/ApplyAssociations.spec.ts
+++ b/libs/gtfs/src/transform/ApplyAssociations.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from 'vitest';
+import {Temporal} from 'temporal-polyfill';
 import {Days, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {STP} from "../model/OverlayRecord";
 import {CRS, PickupDropOffType, StopTime, TUID} from "@gb-transit/gtfs-schema";

--- a/libs/gtfs/src/transform/CreateFeedInfo.spec.ts
+++ b/libs/gtfs/src/transform/CreateFeedInfo.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {createFeedInfo} from "./CreateFeedInfo";
 import {Calendar, CalendarDate} from "@gb-transit/gtfs-schema";
 import {DateRange} from "../build/BuildContext";

--- a/libs/gtfs/src/transform/DropUnknownStops.spec.ts
+++ b/libs/gtfs/src/transform/DropUnknownStops.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {dropUnknownStops} from "./DropUnknownStops";
 import {PickupDropOffType, RouteType, StopTime} from "@gb-transit/gtfs-schema";
 import {Schedule} from "../model/Schedule";

--- a/libs/gtfs/src/transform/Headsigns.spec.ts
+++ b/libs/gtfs/src/transform/Headsigns.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {Days, NO_DAYS, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {STP} from "../model/OverlayRecord";
 import {CRS, PickupDropOffType, RouteType, StopTime} from "@gb-transit/gtfs-schema";

--- a/libs/gtfs/src/transform/LinkedTrips.spec.ts
+++ b/libs/gtfs/src/transform/LinkedTrips.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from "vitest";
+import {Temporal} from "temporal-polyfill";
 import {Days, NO_DAYS, ScheduleCalendar} from "../model/ScheduleCalendar";
 import {STP} from "../model/OverlayRecord";
 import {CRS, PickupDropOffType, RouteType, StopTime, TIPLOC} from "@gb-transit/gtfs-schema";

--- a/libs/gtfs/src/transform/MergeSchedules.spec.ts
+++ b/libs/gtfs/src/transform/MergeSchedules.spec.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect} from 'vitest';
+import {Temporal} from 'temporal-polyfill';
 import {STP} from "../model/OverlayRecord";
 import {mergeSchedules} from "../transform/MergeSchedules";
 import {applyOverlays} from "../transform/ApplyOverlays";

--- a/libs/gtfs/src/transform/ShiftLateNightServices.ts
+++ b/libs/gtfs/src/transform/ShiftLateNightServices.ts
@@ -1,3 +1,4 @@
+import type {Temporal} from "temporal-polyfill";
 import {Schedule} from "../model/Schedule";
 import {STP} from "../model/OverlayRecord";
 import {AgencyID, dayOfWeek} from "@gb-transit/gtfs-schema";

--- a/libs/naptan/package.json
+++ b/libs/naptan/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "dependencies": {
     "csv-parse": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/planarnetwork/dtd2mysql#readme",
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b"
   },
   "engines": {
-    "node": ">=26"
+    "node": ">=22"
   },
   "devDependencies": {
     "@gb-transit/gtfs-loader": "workspace:^",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "nodenext",
     "module": "nodenext",
-    "target": "es2025",
+    "target": "es2024",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "lib": [
-      "esnext"
+      "es2024"
     ],
     "types": [
       "node"

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,6 +449,7 @@ __metadata:
     adm-zip: "npm:0.6.0"
     byline: "npm:5.0.0"
     ssh2: "npm:1.17.0"
+    temporal-polyfill: "npm:1.0.4"
     typescript: "npm:7.0.2"
   languageName: unknown
   linkType: soft
@@ -525,6 +526,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gb-transit/gtfs-schema@workspace:libs/gtfs-schema"
   dependencies:
+    temporal-polyfill: "npm:1.0.4"
     typescript: "npm:7.0.2"
   languageName: unknown
   linkType: soft
@@ -536,6 +538,7 @@ __metadata:
     "@gb-transit/gtfs-schema": "workspace:^"
     memoized-class-decorator: "npm:1.6.1"
     proj4: "npm:2.20.9"
+    temporal-polyfill: "npm:1.0.4"
     typescript: "npm:7.0.2"
   languageName: unknown
   linkType: soft
@@ -1404,6 +1407,7 @@ __metadata:
     memoized-class-decorator: "npm:1.6.1"
     mysql2: "npm:3.23.1"
     proj4: "npm:2.20.9"
+    temporal-polyfill: "npm:1.0.4"
     typescript: "npm:7.0.2"
   bin:
     dtd2mysql: bin/dtd2mysql.sh
@@ -2618,6 +2622,30 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
+  languageName: node
+  linkType: hard
+
+"temporal-polyfill@npm:1.0.4":
+  version: 1.0.4
+  resolution: "temporal-polyfill@npm:1.0.4"
+  dependencies:
+    temporal-spec: "npm:1.0.1"
+    temporal-utils: "npm:1.0.2"
+  checksum: 10c0/b93905805462090e94069841bfa99d162aaec07766a2fa4a8aed28159e3c3296c03a3224b5c6ea14cc65890f299094b21d1702ee6d3cd15cdaae967c22809b33
+  languageName: node
+  linkType: hard
+
+"temporal-spec@npm:1.0.1":
+  version: 1.0.1
+  resolution: "temporal-spec@npm:1.0.1"
+  checksum: 10c0/99f6bfe4a8e59cd0664d0e97706798a1e10d42b1b682da9b60778a4cb9a23362da01ea3d83a674ef426ed743bbab835e2e3d1acea5d2d4a9eabe33863237b014
+  languageName: node
+  linkType: hard
+
+"temporal-utils@npm:1.0.2":
+  version: 1.0.2
+  resolution: "temporal-utils@npm:1.0.2"
+  checksum: 10c0/062cacb33662e4e2547e1ebea98e994d3835d98bf528744256714cd0c4219d43ffd526a500bbce12392468f802a01de058885e8d73453c11ed7ca67fa6e327fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Node 26 was required for one reason: it is the first release to expose `Temporal` as a global, and the calendar is written against it. That put every package on a runtime that is not LTS until October, for an API the rest of the code does not care about the provenance of.

[`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) provides it and hands over to the built-in global wherever there is one, so Node 26 runs exactly the implementation it ran before — the import resolves to the same object (`Temporal === globalThis.Temporal`). Where `Temporal` was reached as a global it is now imported, which is the whole of the change to the date handling: the package exports it as a namespace, so the declarations still read `Temporal.PlainDate`, and the pinned type surface has not moved. Only the four packages that touch it take the dependency, and `@gb-transit/gtfs-schema/scalars` still reaches nothing.

`lib` drops from `esnext` to `es2024`. That is what proves the migration is complete — with no global `Temporal` type, a missed call site does not compile — and it stops an API the floor does not have, `RegExp.escape` or `Float16Array`, being typed as though it did.

`engines` is `>=22` across the eleven workspaces that declare one, and the CI unit matrix runs 22 alongside 26 so the polyfilled and the native path are both exercised.

## One thing was broken below Node 24 rather than merely unavailable

`FeedZip` reports which CIF line failed to parse by throwing from a byline `data` listener, and an error thrown there only reaches `finished()` from Node 24 onwards. On 22 it escaped as an uncaught exception and the stream never settled, so a bad feed would hang instead of naming the line that stopped it. It destroys the stream with that error instead, which reports the same thing on every version. That is the first commit, and it stands on its own.

## Checked

On Node 22.23.2, the floor: `yarn build`, `yarn typecheck`, 943 tests, all four CLIs' `--help`, and `scripts/check-packaged.mjs`, which packs every workspace, installs each tarball on its own and runs it. The suite passes on 22, 24 and 26, and the golden feed fixtures are byte identical across all three, so the polyfill's calendar arithmetic agrees with V8's.

## Left alone

`.nvmrc` still pins 26 for development — the floor is what the packages declare, and the pin reads as deliberate. `dtd-source`, `dtd-schema`, `feed-parser`, `enrich-naptan` and `extend-station-groups` still declare no `engines` at all, as before; `dtd-source` is the one that now carries the polyfill, so it is the candidate if that should be made consistent.
