### PR TITLE
Publish the feed on the website as well as in a release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,13 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - run: node apps/website/dist/build.js
+      - name: Publish the feed alongside the site
+        run: |
+          mkdir -p apps/website/public
+          curl -fsSL --retry 3 --retry-delay 5 \
+            https://github.com/planarnetwork/gb-transit/releases/latest/download/gtfs.zip \
+            -o apps/website/public/gtfs.zip
+          ls -lh apps/website/public/gtfs.zip
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Puts `gtfs.zip` at https://planarnetwork.github.io/gb-transit/gtfs.zip, so that a browser can actually read the feed.

### Why

A release asset is served from `release-assets.githubusercontent.com`, which sends no `Access-Control-Allow-Origin` header, so a page cannot fetch one. `github.io` does not avoid this — it is a different host from `github.com`, and so a different origin. Verified in Chrome:

```
Access to fetch at 'https://github.com/planarnetwork/dtd2mysql/releases/latest/download/gtfs.zip'
from origin 'http://localhost:5179' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

Served from the site instead, it is same-origin for every `planarnetwork.github.io` page, and GitHub Pages sends `Access-Control-Allow-Origin: *` on every response, so it is readable from anywhere else too — including a dev server on localhost.

### What it changes

One step in `pages.yml`, after the site build and before the artifact upload: `curl` the latest release into `apps/website/public/gtfs.zip`.

The workflow already runs on `workflow_run` after **Nightly feed** completes, so the published copy follows the release without needing a schedule of its own. If the download fails the deploy fails and the previous site stays up, feed and all.

Adds ~21MB to the Pages artifact (limit 1GB) and ~21MB per download against the 100GB/month soft bandwidth limit.

### Follow-on

https://github.com/planarnetwork/journey-planning-comparison reads this URL; it is deployed and waiting on this.