### PR TITLE
Read the operator, the trip names, the transfer mode and the areas

### DIFF
--- a/.changeset/gtfs-loader-routes-names-areas.md
+++ b/.changeset/gtfs-loader-routes-names-areas.md
@@ -1,0 +1,36 @@
+---
+"@gb-transit/gtfs-loader": minor
+---
+
+Read the operator, the trip names, the transfer mode and the areas.
+
+A feed loaded as a timetable could say which trip a journey was on and nothing else about it. Four
+files were never opened and four columns of two that were went unsliced, so who ran a train, what
+it was called, and how a change between two stations was made all had to be recovered by reading
+the zip a second time.
+
+`GTFSFeed` gains `routes`, `agencies` and `areas`; `Trip` gains `routeId`, `shortName` and
+`headsign`; `Transfer` gains `mode`. Nothing an existing caller receives changes shape, and a feed
+missing any of these files loads as before with the indexes empty and the fields undefined.
+
+`areas.txt` and `stop_areas.txt` are one index rather than two, because neither is any use without
+the other. Either may arrive first — this feed writes `stop_areas.txt` ahead of `areas.txt` — so
+both sides fill in an entry the other may already have made.
+
+The cost is 9MB on a 290MB load of the GB feed, and no measurable time. That is small because all
+three trip fields go through `intern`: 290,640 trips name 98 routes and 869 headsigns between them.
+`trip_short_name` is the headcode and barely repeats, but a field is a slice of the chunk it was
+decoded from and 290,640 of them would hold the whole of an 18MB `trips.txt` alive, so it has to be
+copied out either way. Interning it costs a lookup and recovers the two thirds that do repeat.
+
+`agency_id` is handed back exactly as the feed wrote it, `=GW` and not `GW`. The equals sign is the
+National Operator Catalogue form that tells a rail operator from the airline with the same two
+letters, so stripping it would reintroduce the collision it exists to prevent and leave the ids
+disagreeing with the ones `@gb-transit/gtfs` composes.
+
+`mode` is the raw string, with `transferModes` to split it. The compound form is the sorted union of
+every link describing a stop pair, since `transfers.txt` is keyed on the pair and can hold one row
+for it, so `BUS|WALK` means the change can be made either way rather than that the bus comes first.
+Which one a journey should be shown as depends on what the caller is optimising, and the feed has
+not ranked them. It travels with a footpath between two stops and nowhere else: a same-stop row
+becomes that stop's interchange time, and a type 4 row becomes a coupling.

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -29,3 +29,11 @@ published — and its surface moves into `@gb-transit/gtfs-loader` as `readFeed`
 `FEED_FILES`, `READ_COLUMNS`, `feedFileOf`, `toRow`, `RawFeed` and `RawOptions`, reached through
 `loadGTFS(source, {raw: true})`. Nothing else moved: the reader is the same code under a different
 name, and `loadGTFS`'s own surface is unchanged.
+
+**Reading the operator, the trip names, the transfer mode and the areas** (#180, #181, #182).
+`@gb-transit/gtfs-loader` gains ten names for the four files it now opens: `Route`, `RouteID` and
+`RouteIndex` for routes.txt, `Agency`, `AgencyID` and `AgencyIndex` for agency.txt, `Area`, `AreaID`
+and `AreaIndex` for areas.txt and stop_areas.txt read as one index, and `transferModes` for splitting
+the pipe separated mode of a transfer. Additions only. The types already exported gained fields —
+`GTFSFeed` has `routes`, `agencies` and `areas`, `Trip` has `routeId`, `shortName` and `headsign`,
+`Transfer` has `mode` — which the surface records by name and so does not show.

--- a/libs/gtfs-loader/src/EntityType.spec.ts
+++ b/libs/gtfs-loader/src/EntityType.spec.ts
@@ -11,6 +11,10 @@ describe("entityTypeOf", () => {
     expect(entityTypeOf("transfers.txt")).to.equal("transfer");
     expect(entityTypeOf("feed_info.txt")).to.equal("feed_info");
     expect(entityTypeOf("stops.txt")).to.equal("stop");
+    expect(entityTypeOf("routes.txt")).to.equal("route");
+    expect(entityTypeOf("agency.txt")).to.equal("agency");
+    expect(entityTypeOf("areas.txt")).to.equal("area");
+    expect(entityTypeOf("stop_areas.txt")).to.equal("stop_area");
   });
 
   it("reads a feed that nests its files in a directory", () => {
@@ -20,9 +24,8 @@ describe("entityTypeOf", () => {
 
   it("ignores the files the loader does not read", () => {
     expect(entityTypeOf("links.txt")).to.equal(undefined);
-    expect(entityTypeOf("routes.txt")).to.equal(undefined);
-    expect(entityTypeOf("agency.txt")).to.equal(undefined);
     expect(entityTypeOf("shapes.txt")).to.equal(undefined);
+    expect(entityTypeOf("attributions.txt")).to.equal(undefined);
   });
 
   it("ignores directory entries", () => {

--- a/libs/gtfs-loader/src/EntityType.ts
+++ b/libs/gtfs-loader/src/EntityType.ts
@@ -8,7 +8,11 @@ export type EntityType =
   | "stop_time"
   | "transfer"
   | "feed_info"
-  | "stop";
+  | "stop"
+  | "route"
+  | "agency"
+  | "area"
+  | "stop_area";
 
 /**
  * The file each entity comes from.
@@ -20,7 +24,11 @@ const FILES: Record<string, EntityType> = {
   "stop_times.txt": "stop_time",
   "transfers.txt": "transfer",
   "feed_info.txt": "feed_info",
-  "stops.txt": "stop"
+  "stops.txt": "stop",
+  "routes.txt": "route",
+  "agency.txt": "agency",
+  "areas.txt": "area",
+  "stop_areas.txt": "stop_area"
 };
 
 /**
@@ -36,17 +44,27 @@ export const COLUMNS: Record<EntityType, readonly string[]> = {
     "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"
   ],
   calendar_date: ["service_id", "date", "exception_type"],
-  trip: ["trip_id", "service_id"],
+  trip: ["trip_id", "service_id", "route_id", "trip_short_name", "trip_headsign"],
   stop_time: ["trip_id", "arrival_time", "departure_time", "stop_id", "pickup_type", "drop_off_type"],
   transfer: [
     "from_stop_id", "to_stop_id", "from_trip_id", "to_trip_id",
-    "transfer_type", "min_transfer_time", "start_time", "end_time"
+    "transfer_type", "min_transfer_time", "mode", "start_time", "end_time"
   ],
   feed_info: ["feed_start_date", "feed_end_date", "feed_version"],
   stop: [
     "stop_id", "stop_code", "stop_name", "stop_desc", "stop_lat", "stop_lon",
     "stop_timezone", "location_type", "parent_station", "platform_code"
-  ]
+  ],
+  route: [
+    "route_id", "agency_id", "route_short_name", "route_long_name", "route_type",
+    "route_color", "route_text_color", "route_url", "route_desc"
+  ],
+  agency: [
+    "agency_id", "agency_name", "agency_url", "agency_timezone", "agency_lang", "agency_phone",
+    "agency_fare_url"
+  ],
+  area: ["area_id", "area_name"],
+  stop_area: ["area_id", "stop_id"]
 };
 
 /**

--- a/libs/gtfs-loader/src/FeedBuilder.spec.ts
+++ b/libs/gtfs-loader/src/FeedBuilder.spec.ts
@@ -247,6 +247,138 @@ describe("FeedBuilder", () => {
     expect(builder.build().stops.A.locationType).to.equal(0);
   });
 
+  it("reads a route", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("route", {
+      route_id: "GW", agency_id: "=GW", route_short_name: "GWR",
+      route_long_name: "Great Western Railway", route_type: "2", route_color: "0a493e",
+      route_text_color: "ffffff", route_url: "https://www.gwr.com/", route_desc: ""
+    });
+
+    const route = builder.build().routes.GW;
+
+    expect(route.id).to.equal("GW");
+    expect(route.agencyId).to.equal("=GW");
+    expect(route.shortName).to.equal("GWR");
+    expect(route.longName).to.equal("Great Western Railway");
+    expect(route.type).to.equal(2);
+    expect(route.color).to.equal("0a493e");
+  });
+
+  /**
+   * The equals sign is the National Operator Catalogue form, which distinguishes a rail operator
+   * from the airline with the same two letters. Stripping it here would reintroduce the collision
+   * it exists to prevent, and leave routes.txt pointing at an agency id agency.txt does not have.
+   */
+  it("keeps an agency id exactly as the feed wrote it", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("agency", {
+      agency_id: "=GW", agency_name: "Great Western Railway", agency_url: "https://www.gwr.com/",
+      agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "0345 700 0125"
+    });
+    builder.add("route", { route_id: "GW", agency_id: "=GW", route_type: "2" });
+
+    const feed = builder.build();
+
+    expect(Object.keys(feed.agencies)).to.deep.equal(["=GW"]);
+    expect(feed.agencies["=GW"].name).to.equal("Great Western Railway");
+    expect(feed.agencies[feed.routes.GW.agencyId as string].name).to.equal("Great Western Railway");
+  });
+
+  it("gives a trip its route, its headcode and its headsign", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("trip", {
+      trip_id: "G14978_A_B", service_id: "s1", route_id: "GW",
+      trip_short_name: "GW130700", trip_headsign: "PLYMOUTH"
+    });
+
+    const [trip] = builder.build().trips;
+
+    expect(trip.routeId).to.equal("GW");
+    expect(trip.shortName).to.equal("GW130700");
+    expect(trip.headsign).to.equal("PLYMOUTH");
+  });
+
+  it("leaves a trip's route and names undefined when the feed gives none", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("trip", { trip_id: "t1", service_id: "s1" });
+
+    const [trip] = builder.build().trips;
+
+    expect(trip.routeId).to.equal(undefined);
+    expect(trip.shortName).to.equal(undefined);
+    expect(trip.headsign).to.equal(undefined);
+  });
+
+  it("keeps how a transfer is made", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("transfer", {
+      from_stop_id: "910GKNGX", to_stop_id: "910GPADTON", min_transfer_time: "900",
+      mode: "TRANSFER|TUBE"
+    });
+    builder.add("transfer", { from_stop_id: "A", to_stop_id: "B", min_transfer_time: "300" });
+
+    const feed = builder.build();
+
+    expect(feed.transfers["910GKNGX"][0].mode).to.equal("TRANSFER|TUBE");
+    expect(feed.transfers.A[0].mode).to.equal(undefined);
+  });
+
+  it("reads an area from areas.txt and stop_areas.txt together", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("area", { area_id: "0032", area_name: "LONDON ZONES 1-2" });
+    builder.add("stop_area", { area_id: "0032", stop_id: "910GEUSTON" });
+    builder.add("stop_area", { area_id: "0032", stop_id: "910GCHRX" });
+
+    const area = builder.build().areas["0032"];
+
+    expect(area.id).to.equal("0032");
+    expect(area.name).to.equal("LONDON ZONES 1-2");
+    expect(area.stops).to.deep.equal(["910GEUSTON", "910GCHRX"]);
+  });
+
+  /**
+   * The GB feed writes stop_areas.txt ahead of areas.txt, so the memberships of an area arrive
+   * before it has been named.
+   */
+  it("reads an area whose stops arrive before its name", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("stop_area", { area_id: "0032", stop_id: "910GEUSTON" });
+    builder.add("area", { area_id: "0032", area_name: "LONDON ZONES 1-2" });
+
+    const area = builder.build().areas["0032"];
+
+    expect(area.name).to.equal("LONDON ZONES 1-2");
+    expect(area.stops).to.deep.equal(["910GEUSTON"]);
+  });
+
+  it("gives an area with no stops an empty list, and one with no name no name", () => {
+    const builder = new FeedBuilder();
+
+    builder.add("area", { area_id: "0032", area_name: "LONDON ZONES 1-2" });
+    builder.add("stop_area", { area_id: "0033", stop_id: "910GEUSTON" });
+
+    const { areas } = builder.build();
+
+    expect(areas["0032"].stops).to.deep.equal([]);
+    expect(areas["0033"].name).to.equal(undefined);
+  });
+
+  it("gives a feed with none of those files empty indexes", () => {
+    const feed = new FeedBuilder().build();
+
+    expect(feed.routes).to.deep.equal({});
+    expect(feed.agencies).to.deep.equal({});
+    expect(feed.areas).to.deep.equal({});
+  });
+
   /**
    * A feed that leaves stop_code empty names the station by its stop_id. If an empty field were
    * read as "" rather than undefined every such station would claim the same code and the

--- a/libs/gtfs-loader/src/FeedBuilder.ts
+++ b/libs/gtfs-loader/src/FeedBuilder.ts
@@ -1,4 +1,4 @@
-import type { CalendarIndex, DateIndex, DayOfWeek, Interchange, StopIndex, TransfersByOrigin, Trip, TripLink } from "./GTFS.js";
+import type { AgencyIndex, Area, AreaIndex, CalendarIndex, DateIndex, DayOfWeek, Interchange, RouteIndex, StopIndex, TransfersByOrigin, Trip, TripLink } from "./GTFS.js";
 import type { EntityType } from "./EntityType.js";
 import type { Row } from "./CSVParser.js";
 import type { FeedInfo, GTFSFeed } from "./GTFSLoader.js";
@@ -27,6 +27,9 @@ export class FeedBuilder {
   private readonly calendars: CalendarIndex = {};
   private readonly dates: Record<string, DateIndex> = {};
   private readonly stops: StopIndex = {};
+  private readonly routes: RouteIndex = {};
+  private readonly agencies: AgencyIndex = {};
+  private readonly areas: AreaIndex = {};
   /**
    * Keyed by trip rather than stored on the trip, because stop_times.txt may arrive before
    * trips.txt. A Map rather than an object: a feed has hundreds of thousands of trips, and an
@@ -49,6 +52,10 @@ export class FeedBuilder {
       case "stop_time": this.addStopTime(row); break;
       case "feed_info": this.addFeedInfo(row); break;
       case "stop": this.addStop(row); break;
+      case "route": this.addRoute(row); break;
+      case "agency": this.addAgency(row); break;
+      case "area": this.addArea(row); break;
+      case "stop_area": this.addStopArea(row); break;
     }
   }
 
@@ -81,6 +88,9 @@ export class FeedBuilder {
       links: this.links,
       interchange: this.interchange,
       stops: this.stops,
+      routes: this.routes,
+      agencies: this.agencies,
+      areas: this.areas,
       feedInfo: this.feedInfo
     };
   }
@@ -171,8 +181,9 @@ export class FeedBuilder {
     }
     else {
       const transfers = this.transfers[origin] ?? [];
+      const mode = row.mode === undefined ? undefined : this.intern(row.mode);
 
-      transfers.push({ origin, destination, duration, startTime, endTime });
+      transfers.push({ origin, destination, duration, startTime, endTime, mode });
       this.transfers[origin] = transfers;
     }
   }
@@ -211,7 +222,10 @@ export class FeedBuilder {
       serviceId: this.intern(row.service_id as string),
       tripId: this.intern(row.trip_id as string),
       stopTimes: [],
-      service: {} as Service
+      service: {} as Service,
+      routeId: row.route_id === undefined ? undefined : this.intern(row.route_id),
+      shortName: row.trip_short_name === undefined ? undefined : this.intern(row.trip_short_name),
+      headsign: row.trip_headsign === undefined ? undefined : this.intern(row.trip_headsign)
     });
   }
 
@@ -259,6 +273,59 @@ export class FeedBuilder {
       parentStation: row.parent_station === undefined ? undefined : this.intern(row.parent_station),
       platformCode: row.platform_code
     };
+  }
+
+  private addRoute(row: Row): void {
+    const id = this.intern(row.route_id as string);
+
+    this.routes[id] = {
+      id,
+      agencyId: row.agency_id === undefined ? undefined : this.intern(row.agency_id),
+      shortName: row.route_short_name,
+      longName: row.route_long_name,
+      type: +(row.route_type as string),
+      color: row.route_color,
+      textColor: row.route_text_color,
+      url: row.route_url,
+      description: row.route_desc
+    };
+  }
+
+  private addAgency(row: Row): void {
+    const id = this.intern(row.agency_id as string);
+
+    this.agencies[id] = {
+      id,
+      name: row.agency_name,
+      url: row.agency_url,
+      timezone: row.agency_timezone,
+      lang: row.agency_lang,
+      phone: row.agency_phone,
+      fareUrl: row.agency_fare_url
+    };
+  }
+
+  /**
+   * Either file may arrive first - the GB feed writes stop_areas.txt ahead of areas.txt - so both
+   * sides fill in an entry the other may already have made rather than replacing it.
+   */
+  private addArea(row: Row): void {
+    this.area(row.area_id as string).name = row.area_name;
+  }
+
+  private addStopArea(row: Row): void {
+    this.area(row.area_id as string).stops.push(this.intern(row.stop_id as string));
+  }
+
+  private area(areaId: string): Area {
+    const id = this.intern(areaId);
+    const existing = this.areas[id];
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    return this.areas[id] = { id, stops: [] };
   }
 
 }

--- a/libs/gtfs-loader/src/GTFS.ts
+++ b/libs/gtfs-loader/src/GTFS.ts
@@ -42,6 +42,7 @@ export interface Transfer {
   duration: Duration;
   startTime: Time;
   endTime: Time;
+  mode?: string;
 }
 
 /**
@@ -63,6 +64,9 @@ export interface Trip {
   stopTimes: StopTime[];
   serviceId: ServiceID;
   service: ServiceCalendar;
+  routeId?: RouteID;
+  shortName?: string;
+  headsign?: string;
 }
 
 /**
@@ -131,6 +135,73 @@ export interface Stop {
  * Stops indexed by ID
  */
 export type StopIndex = Record<StopID, Stop>;
+
+/**
+ * GTFS route_id
+ */
+export type RouteID = string;
+
+/**
+ * GTFS agency_id
+ */
+export type AgencyID = string;
+
+/**
+ * GTFS area_id
+ */
+export type AreaID = string;
+
+/**
+ * GTFS route
+ */
+export interface Route {
+  id: RouteID;
+  agencyId?: AgencyID;
+  shortName?: string;
+  longName?: string;
+  type: number;
+  color?: string;
+  textColor?: string;
+  url?: string;
+  description?: string;
+}
+
+/**
+ * Routes indexed by ID
+ */
+export type RouteIndex = Record<RouteID, Route>;
+
+/**
+ * GTFS agency. The id is as the feed wrote it, which in a GB rail feed is the NOC form, `=AW`.
+ */
+export interface Agency {
+  id: AgencyID;
+  name?: string;
+  url?: string;
+  timezone?: string;
+  lang?: string;
+  phone?: string;
+  fareUrl?: string;
+}
+
+/**
+ * Agencies indexed by ID
+ */
+export type AgencyIndex = Record<AgencyID, Agency>;
+
+/**
+ * A flat, named set of stops - areas.txt and stop_areas.txt read as one thing.
+ */
+export interface Area {
+  id: AreaID;
+  name?: string;
+  stops: StopID[];
+}
+
+/**
+ * Areas indexed by ID
+ */
+export type AreaIndex = Record<AreaID, Area>;
 
 /**
  * Minimum time needed to change vehicles at each stop

--- a/libs/gtfs-loader/src/GTFSLoader.spec.ts
+++ b/libs/gtfs-loader/src/GTFSLoader.spec.ts
@@ -8,16 +8,19 @@ const FEED = {
   "calendar.txt":
     "service_id,start_date,end_date,monday,tuesday,wednesday,thursday,friday,saturday,sunday\n"
     + "s1,20250101,20251231,1,1,1,1,1,1,1\n",
-  "trips.txt": "trip_id,service_id\nt1,s1\n",
+  "trips.txt":
+    "route_id,service_id,trip_id,trip_headsign,trip_short_name\n"
+    + "r1,s1,t1,Beeton,X100\n",
   "stop_times.txt":
     "trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type\n"
     + "t1,10:00:00,10:00:00,A,1,0,0\n"
     + "t1,10:30:00,10:30:00,B,2,0,0\n",
-  "transfers.txt": "from_stop_id,to_stop_id,min_transfer_time\nA,A,300\n",
+  "transfers.txt": "from_stop_id,to_stop_id,min_transfer_time,mode\nA,A,300,\nA,B,600,TRANSFER|TUBE\n",
   "feed_info.txt": "feed_start_date,feed_end_date,feed_version\n20250101,20251231,1\n",
-  // present in a real feed, and of no interest to the loader
-  "routes.txt": "route_id,route_short_name\nr1,X\n",
-  "agency.txt": "agency_id,agency_name\na1,Anytown Buses\n"
+  "routes.txt": "route_id,agency_id,route_short_name,route_type\nr1,=a1,X,2\n",
+  "agency.txt": "agency_id,agency_name\n=a1,Anytown Buses\n",
+  "areas.txt": "area_id,area_name\nz1,Anytown Central\n",
+  "stop_areas.txt": "area_id,stop_id\nz1,A\nz1,B\n"
 };
 
 function feedZip(files: Record<string, string> = FEED): Uint8Array<ArrayBuffer> {
@@ -28,6 +31,10 @@ function feedZip(files: Record<string, string> = FEED): Uint8Array<ArrayBuffer> 
   }
 
   return zipSync(contents);
+}
+
+function without(...files: string[]): Record<string, string> {
+  return Object.fromEntries(Object.entries(FEED).filter(([name]) => !files.includes(name)));
 }
 
 describe("loadGTFS", () => {
@@ -91,6 +98,47 @@ describe("loadGTFS", () => {
     expect(feed.links.length).to.equal(0);
     expect(Object.keys(feed.interchange).length).to.equal(0);
     expect(Object.keys(feed.transfers).length).to.equal(0);
+  });
+
+  it("resolves a trip through its route to its operator", async () => {
+    const feed = await loadGTFS(feedZip());
+    const [trip] = feed.trips;
+
+    expect(trip.shortName).to.equal("X100");
+    expect(trip.headsign).to.equal("Beeton");
+    expect(feed.routes[trip.routeId as string].shortName).to.equal("X");
+    expect(feed.agencies[feed.routes[trip.routeId as string].agencyId as string].name)
+      .to.equal("Anytown Buses");
+  });
+
+  it("reads the areas as one index", async () => {
+    const { areas } = await loadGTFS(feedZip());
+
+    expect(areas.z1.name).to.equal("Anytown Central");
+    expect(areas.z1.stops).to.deep.equal(["A", "B"]);
+  });
+
+  it("reads how a transfer is made", async () => {
+    const { transfers } = await loadGTFS(feedZip());
+
+    expect(transfers.A[0].mode).to.equal("TRANSFER|TUBE");
+  });
+
+  it("loads a feed that has none of the files those come from", async () => {
+    const feed = await loadGTFS(feedZip(without("routes.txt", "agency.txt", "areas.txt", "stop_areas.txt")));
+
+    expect(feed.trips.length).to.equal(1);
+    expect(feed.routes).to.deep.equal({});
+    expect(feed.agencies).to.deep.equal({});
+    expect(feed.areas).to.deep.equal({});
+  });
+
+  it("gives a trip no route when trips.txt does not name one", async () => {
+    const feed = await loadGTFS(feedZip({ ...FEED, "trips.txt": "trip_id,service_id\nt1,s1\n" }));
+
+    expect(feed.trips[0].routeId).to.equal(undefined);
+    expect(feed.trips[0].shortName).to.equal(undefined);
+    expect(feed.trips[0].headsign).to.equal(undefined);
   });
 
   it("reports progress and finishes with the building phase", async () => {

--- a/libs/gtfs-loader/src/GTFSLoader.ts
+++ b/libs/gtfs-loader/src/GTFSLoader.ts
@@ -1,4 +1,4 @@
-import type { DateNumber, Interchange, StopIndex, TransfersByOrigin, Trip, TripLink } from "./GTFS.js";
+import type { AgencyIndex, AreaIndex, DateNumber, Interchange, RouteIndex, StopIndex, TransfersByOrigin, Trip, TripLink } from "./GTFS.js";
 import { COLUMNS, entityTypeOf } from "./EntityType.js";
 import { CSVParser } from "./CSVParser.js";
 import { FeedBuilder } from "./FeedBuilder.js";
@@ -190,6 +190,9 @@ export interface GTFSFeed {
   links: TripLink[];
   interchange: Interchange;
   stops: StopIndex;
+  routes: RouteIndex;
+  agencies: AgencyIndex;
+  areas: AreaIndex;
   /** feed_info.txt, which a feed does not have to provide */
   feedInfo?: FeedInfo;
 }

--- a/libs/gtfs-loader/src/Normalise.spec.ts
+++ b/libs/gtfs-loader/src/Normalise.spec.ts
@@ -37,6 +37,9 @@ function feed(stops: Stop[], overrides: Partial<GTFSFeed> = {}): GTFSFeed {
     links: [],
     interchange: {},
     stops: Object.fromEntries(stops.map(s => [s.id, s])),
+    routes: {},
+    agencies: {},
+    areas: {},
     ...overrides
   };
 }

--- a/libs/gtfs-loader/src/TransferMode.spec.ts
+++ b/libs/gtfs-loader/src/TransferMode.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { transferModes } from "./TransferMode.js";
+
+describe("transferModes", () => {
+
+  it("reads a single mode", () => {
+    expect(transferModes("TUBE")).to.deep.equal(["TUBE"]);
+  });
+
+  it("reads every tag of a compound mode", () => {
+    expect(transferModes("TRANSFER|TUBE")).to.deep.equal(["TRANSFER", "TUBE"]);
+    expect(transferModes("BUS|WALK")).to.deep.equal(["BUS", "WALK"]);
+  });
+
+  it("reads a bare TRANSFER as itself", () => {
+    expect(transferModes("TRANSFER")).to.deep.equal(["TRANSFER"]);
+  });
+
+  it("gives nothing for a transfer with no mode", () => {
+    expect(transferModes(undefined)).to.deep.equal([]);
+    expect(transferModes("")).to.deep.equal([]);
+    expect(transferModes("|")).to.deep.equal([]);
+  });
+
+});

--- a/libs/gtfs-loader/src/TransferMode.ts
+++ b/libs/gtfs-loader/src/TransferMode.ts
@@ -1,0 +1,10 @@
+/**
+ * The tags of a transfer's mode, which the feed writes pipe separated and sorted - `BUS|WALK`.
+ */
+export function transferModes(mode: string | undefined): string[] {
+  if (mode === undefined || mode === "") {
+    return [];
+  }
+
+  return mode.split("|").filter(tag => tag !== "");
+}

--- a/libs/gtfs-loader/src/index.ts
+++ b/libs/gtfs-loader/src/index.ts
@@ -14,9 +14,11 @@ export type { LoadOptions, LoadProgress } from "./Progress.js";
 // they mean something else: those are the rows a GB rail feed is written as, these are what any
 // feed is read into. Same words, opposite directions - see the README.
 export type {
-  Calendar, CalendarIndex, DateIndex, DateNumber, DayOfWeek, Duration, Interchange, ServiceID,
-  Stop, StopID, StopIndex, StopTime, Time, Transfer, TransfersByOrigin, Trip, TripID, TripLink
+  Agency, AgencyID, AgencyIndex, Area, AreaID, AreaIndex, Calendar, CalendarIndex, DateIndex,
+  DateNumber, DayOfWeek, Duration, Interchange, Route, RouteID, RouteIndex, ServiceID, Stop, StopID,
+  StopIndex, StopTime, Time, Transfer, TransfersByOrigin, Trip, TripID, TripLink
 } from "./GTFS.js";
+export { transferModes } from "./TransferMode.js";
 export { LinkedService, Service } from "./Service.js";
 export type { ServiceCalendar } from "./Service.js";
 export { addDays, daysBetween, getDateNumber, getDayOfWeek } from "./DateUtil.js";

--- a/type-surface.json
+++ b/type-surface.json
@@ -232,6 +232,12 @@
     "withoutPlaceholders"
   ],
   "gtfs-loader": [
+    "Agency",
+    "AgencyID",
+    "AgencyIndex",
+    "Area",
+    "AreaID",
+    "AreaIndex",
     "COLUMNS",
     "CSVParser",
     "Calendar",
@@ -262,6 +268,9 @@
     "RawOptions",
     "ReadFeedOptions",
     "ReadZipOptions",
+    "Route",
+    "RouteID",
+    "RouteIndex",
     "Row",
     "Service",
     "ServiceCalendar",
@@ -296,7 +305,8 @@
     "readZip",
     "sizeOf",
     "toChunks",
-    "toRow"
+    "toRow",
+    "transferModes"
   ],
   "gtfs-output": [
     "CSVRowWriter",


### PR DESCRIPTION
Closes #180, closes #181, closes #182, and adds `areas.txt`/`stop_areas.txt` alongside them.

A feed loaded as a timetable could say which trip a journey was on and nothing else about it. Four files were never opened, and four columns of two that were went unsliced.

`GTFSFeed` gains `routes`, `agencies` and `areas`; `Trip` gains `routeId`, `shortName` and `headsign`; `Transfer` gains `mode`. Additive throughout — a feed with none of those files loads as it did, with the indexes empty and the fields undefined.

`areas.txt` and `stop_areas.txt` come back as one `Record<AreaID, Area>` of `{ id, name?, stops }`, because neither file is any use without the other. Either may arrive first — this feed writes `stop_areas.txt` ahead of `areas.txt` — so both sides fill in an entry the other may already have made.

## What it costs

Measured on the published GB feed, `--expose-gc`, heap after load:

|        | master   | this branch |
| ------ | -------- | ----------- |
| heap   | 289.7 MB | 299.1 MB    |
| load   | ~2.9 s   | ~2.7–3.0 s  |

**+9.4 MB, +3%, no time cost.** #181 offered a `LoadOptions` flag to skip the trip names if the cost was real; it isn't, so there isn't one.

It is small because all three trip fields go through the existing `intern`: 290,640 trips name only 98 routes and 869 headsigns between them. `trip_short_name` is the headcode and barely repeats (101,519 distinct), but a field is a slice of the chunk it was decoded from, so 290,640 of them would hold the whole of an 18 MB `trips.txt` alive — it has to be copied out either way, and interning it costs a lookup while recovering the two thirds that do repeat.

## Two calls that went against what the issues leaned toward

**`agency_id` is kept as the feed wrote it, `=GW` and not `GW`.** #180 read the hand-stripping in consumers as a sign the decision belonged here. `libs/gtfs/src/transform/Noc.ts` says otherwise: the equals sign is the National Operator Catalogue form that tells a rail operator from the airline with the same two letters. Stripping it would reintroduce the collision it exists to prevent, and leave the loader's ids disagreeing with the ones this repository's own writer composes. A consumer stripping it wants a display code, which is presentation.

**`mode` is the raw string, with `transferModes` to split it.** #182 described consumers taking the first tag that names a way of travelling. `MergeTransfers.ts` shows the compound is the *sorted union* of every link describing that stop pair — `transfers.txt` is keyed on the pair and can hold one row for it, so `BUS|WALK` means the change can be made either way, not that the bus comes first. First-tag-wins is arbitrary given that, so the helper returns every tag and leaves the choice to whoever knows if they want the quickest or the step-free one.

Also worth knowing: `mode` travels with a footpath between two distinct stops and nowhere else. A same-stop row becomes that stop's interchange time, a bare number of seconds with nothing to hang it on, and a type 4 row becomes a coupling.

## Verifying

The cases the issues name, against https://planarnetwork.github.io/gb-transit/gtfs.zip:

- `G14978_20260914_20261210` → `routeId: "GW"` → route *Great Western Railway* → agency `=GW`, *GWR*
- the same trip carries headcode `GW130700` and headsign `Plymouth`
- `910GKNGX` → `910GPADTON` comes back `TRANSFER|TUBE`
- 98 routes, 41 agencies, 729 areas

Unit cover for the `=`-prefixed agency id, a feed with none of the four files, a trips.txt naming no route, a compound mode, a bare `TRANSFER`, a feed with no `mode` column, and an area whose stops arrive before its name.

## Not in here

The raptor-side `Network` passthrough. `Trip.routeId`, the names and `Transfer.mode` all reach `Network` already, since it holds this package's own `Trip[]` and `Transfer[]` — but resolving `routeId` to an operator from a result still needs the feed alive. Worth a follow-up there, with care over the name: raptor's existing `Routes`/`RouteIdx` mean trips sharing a stop sequence, not GTFS routes.