### PR TITLE
Put Bond Street back in Mayfair

### DIFF
--- a/.changeset/bond-street-coordinate.md
+++ b/.changeset/bond-street-coordinate.md
@@ -1,0 +1,24 @@
+---
+"@gb-transit/gtfs": patch
+---
+
+Put Bond Street back in Mayfair.
+
+Bond Street and both of its Elizabeth line platforms were published 21km east, in Dagenham. The
+override in `station-coordinates.ts` read `"stop_lon": 0.15`, which is the "51.514°N 0.15°W" of the
+station's Wikipedia infobox copied without the W. Canary Wharf had the same injury from the same
+source and was published 2.5km out, in the river off Blackwall. Both signs are now negative.
+
+Neither station could be rescued by anything downstream. NaPTAN ships its rail records for both with
+the position left blank, so they are two of the fourteen stations still relying on the override
+file, and the bounds check cannot see a London longitude with its sign lost — it is comfortably
+inside Great Britain.
+
+The DTD can. Its own grid reference put Bond Street on Davies Street all along, and `toStop`
+discarded it for the override without ever comparing the two. It now does: where an override and the
+grid reference disagree by more than 5km, the DTD's position is kept and the station is named on
+stderr, while the name and the accessibility the override also carries still apply. 5km is chosen to
+sit above every honest disagreement — the grid reference is rounded to 100m and Birmingham New
+Street's is 1.3km from the platforms, with the override in the right — and the largest across all
+2,764 stations both sources describe is 3.3km. A station the DTD could not locate at all has only
+the override, so it is taken as given.

--- a/libs/dtd-source/src/cif/CifFileSource.spec.ts
+++ b/libs/dtd-source/src/cif/CifFileSource.spec.ts
@@ -79,7 +79,10 @@ const range = {
 
 const MSN = [
   "/!! Start of file",
-  station("TONBRIDGE", "TONBDG", "TON", 15862, 61462),
+  // 558,600 east and 146,200 north, which is Tonbridge. It read 15862, putting
+  // the station 28km away near Ashford, and nothing minded until an override
+  // that disagrees with the feed by that much stopped being taken.
+  station("TONBRIDGE", "TONBDG", "TON", 15586, 61462),
   station("SEVENOAKS", "SEVNOKS", "SEV", 15525, 61550),
   station("HILDENBOROUGH", "HLDNBRO", "HLD", 15558, 61478)
 ];

--- a/libs/gtfs/src/data/station-coordinates.ts
+++ b/libs/gtfs/src/data/station-coordinates.ts
@@ -1067,7 +1067,7 @@ export const stationCoordinates: StationCoordinates = {
   "BDS": {
     "stop_name": "Bond Street (Elizabeth line)",
     "stop_lat": 51.514,
-    "stop_lon": 0.15,
+    "stop_lon": -0.15,
     "wheelchair_boarding": 0
   },
   "BDT": {
@@ -3863,7 +3863,7 @@ export const stationCoordinates: StationCoordinates = {
   "CWX": {
     "stop_name": "Canary Wharf (Elizabeth line)",
     "stop_lat": 51.5061,
-    "stop_lon": 0.01578,
+    "stop_lon": -0.01578,
     "wheelchair_boarding": 1
   },
   "CYB": {

--- a/libs/gtfs/src/source/StationRecord.spec.ts
+++ b/libs/gtfs/src/source/StationRecord.spec.ts
@@ -1,0 +1,112 @@
+import {describe, it, expect, vi, afterEach} from "vitest";
+import {StationRecord, metresApart, toStop} from "./StationRecord";
+import {StationCoordinates} from "./TimetableSource";
+
+/**
+ * Bond Street's grid reference, as the MSN gives it: 528,500 east and 181,000
+ * north, which is Davies Street.
+ */
+const bondStreet: StationRecord = {
+  crs_code: "BDS",
+  tiploc_code: "BONDST",
+  station_name: "BOND STREET EL",
+  cate_interchange_status: 3,
+  easting: 15285,
+  northing: 61810
+};
+
+function overrides(stop_lat: number, stop_lon: number): StationCoordinates {
+  return {
+    BDS: {stop_name: "Bond Street (Elizabeth line)", stop_lat, stop_lon, wheelchair_boarding: 0}
+  };
+}
+
+describe("metresApart", () => {
+
+  it("is zero for the same place", () => {
+    expect(metresApart({stop_lat: 51.514, stop_lon: -0.15}, {stop_lat: 51.514, stop_lon: -0.15}))
+      .to.equal(0);
+  });
+
+  it("measures a degree of latitude", () => {
+    const apart = metresApart({stop_lat: 51, stop_lon: -0.15}, {stop_lat: 52, stop_lon: -0.15});
+
+    expect(apart).to.be.greaterThan(110000);
+    expect(apart).to.be.lessThan(112000);
+  });
+
+  // A degree of longitude is a degree of latitude times the cosine of it, so a
+  // measurement that ignores the convergence would call this 111km.
+  it("narrows a degree of longitude towards the pole", () => {
+    const apart = metresApart({stop_lat: 51.5, stop_lon: 0}, {stop_lat: 51.5, stop_lon: 1});
+
+    expect(apart).to.be.greaterThan(68000);
+    expect(apart).to.be.lessThan(70000);
+  });
+
+});
+
+describe("toStop", () => {
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("takes the override, which is surveyed where the grid reference is rounded", () => {
+    const stop = toStop(bondStreet, overrides(51.514, -0.15));
+
+    expect(stop.stop_lat).to.equal(51.514);
+    expect(stop.stop_lon).to.equal(-0.15);
+    expect(stop.located).to.equal(true);
+  });
+
+  /**
+   * What #187 was: the longitude copied out of "51.514N 0.15W" without its
+   * sign, which put Bond Street and both its platforms in Dagenham. Inside the
+   * bounds of the feed, so only this catches it.
+   */
+  it("refuses an override that cannot be describing the same station", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const stop = toStop(bondStreet, overrides(51.514, 0.15));
+
+    expect(stop.stop_lon).to.be.closeTo(-0.1496, 0.001);
+    expect(stop.stop_lat).to.be.closeTo(51.5133, 0.001);
+    expect(warn.mock.calls[0][0]).to.contain("BDS is 21km from where the DTD puts it");
+  });
+
+  it("keeps the rest of an override whose coordinate it refused", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(toStop(bondStreet, overrides(51.514, 0.15)).stop_name)
+      .to.equal("Bond Street (Elizabeth line)");
+  });
+
+  // The DTD locates most stations to within a few hundred metres and some of
+  // them, Birmingham New Street among them, to little better than a kilometre.
+  // A check that fired on those would be turned off.
+  it("allows the disagreement an honest override has", () => {
+    const stop = toStop(bondStreet, overrides(51.5, -0.16));
+
+    expect(stop.stop_lat).to.equal(51.5);
+    expect(stop.stop_lon).to.equal(-0.16);
+  });
+
+  /**
+   * The override is the only source for a station the DTD leaves at zeroes, so
+   * there is nothing to disagree with and nothing to refuse. Without this the
+   * check would throw away the coordinate of every station that most needs one.
+   */
+  it("takes an override for a station the DTD could not locate", () => {
+    const unlocated = {...bondStreet, easting: null, northing: null};
+    const stop = toStop(unlocated, overrides(51.514, -0.15));
+
+    expect(stop.stop_lat).to.equal(51.514);
+    expect(stop.stop_lon).to.equal(-0.15);
+  });
+
+  it("leaves a station with no override where the DTD put it", () => {
+    const stop = toStop(bondStreet, {});
+
+    expect(stop.stop_lat).to.be.closeTo(51.5133, 0.001);
+    expect(stop.stop_name).to.equal("BOND STREET EL");
+  });
+
+});

--- a/libs/gtfs/src/source/StationRecord.ts
+++ b/libs/gtfs/src/source/StationRecord.ts
@@ -55,13 +55,55 @@ function position(row: StationRecord): {stop_lon: number, stop_lat: number, loca
     : {...NOWHERE, located: false};
 }
 
+const MAX_DISAGREEMENT_METRES = 5000;
+
+const EARTH_RADIUS_METRES = 6371000;
+
+export function metresApart(
+  a: {stop_lat: number, stop_lon: number},
+  b: {stop_lat: number, stop_lon: number}
+): number {
+  const radians = Math.PI / 180;
+  const north = (b.stop_lat - a.stop_lat) * radians;
+  const east = (b.stop_lon - a.stop_lon) * radians * Math.cos((a.stop_lat + b.stop_lat) / 2 * radians);
+
+  return Math.hypot(north, east) * EARTH_RADIUS_METRES;
+}
+
+function agreeing(
+  crs: string,
+  override: StationCoordinates[string] | undefined,
+  dtd: {stop_lat: number, stop_lon: number, located: boolean}
+): StationCoordinates[string] | Omit<StationCoordinates[string], "stop_lat" | "stop_lon"> | undefined {
+  if (override === undefined || !dtd.located) {
+    return override;
+  }
+
+  const apart = metresApart(dtd, override);
+
+  if (apart <= MAX_DISAGREEMENT_METRES) {
+    return override;
+  }
+
+  const {stop_lat, stop_lon, ...rest} = override;
+
+  console.warn(
+    `${crs} is ${Math.round(apart / 1000)}km from where the DTD puts it - ` +
+    `override ${stop_lat},${stop_lon} against ${dtd.stop_lat},${dtd.stop_lon}. ` +
+    `Keeping the DTD's position: check station-coordinates.ts.`
+  );
+
+  return rest;
+}
+
 /**
  * Turn a station record into a GTFS stop.
  *
  * The coordinates are OSGB eastings and northings held in a form that has to be
  * undone before projecting - `(easting - 10000) * 100` - and then overlaid with
- * whatever `station-coordinates.ts` says. Both halves go when the coordinates
- * come from a source that has them in WGS84 already.
+ * whatever `station-coordinates.ts` says, unless the two disagree by more than
+ * anything that could be a survey. Both halves go when the coordinates come
+ * from a source that has them in WGS84 already.
  *
  * The CRS and the TIPLOC are both kept: the CRS is what the build identifies a
  * station by and what the file publishes as `stop_code`, and the TIPLOC is what
@@ -70,6 +112,7 @@ function position(row: StationRecord): {stop_lon: number, stop_lat: number, loca
  */
 export function toStop(row: StationRecord, overrides: StationCoordinates): Stop {
   const {stop_lon, stop_lat, located} = position(row);
+  const override = agreeing(row.crs_code, overrides[row.crs_code], {stop_lat, stop_lon, located});
 
   return Object.assign({
     stop_id: stationId(row.tiploc_code),
@@ -87,5 +130,5 @@ export function toStop(row: StationRecord, overrides: StationCoordinates): Stop 
     stop_lon,
     stop_lat,
     located
-  } as unknown as Stop, overrides[row.crs_code]);
+  } as unknown as Stop, override);
 }


### PR DESCRIPTION
Closes #187.

## What was wrong

`station-coordinates.ts` held Bond Street at `"stop_lon": 0.15`. The station's Wikipedia infobox
reads 51.514°N 0.15°**W**, and the W was lost on the way in. `+0.15` is 21km due east — Dagenham,
where the issue reports it. The station and both its Elizabeth line platforms are there in the
published feed:

```
9100BONDSTA,BDS,Bond Street (Elizabeth line) Platform A,...,0.15,51.514
9100BONDSTB,BDS,Bond Street (Elizabeth line) Platform B,...,0.15,51.514
910GBONDST,BDS,Bond Street (Elizabeth line),...,0.15,51.514
```

Comparing every override against the DTD's own grid reference turns up exactly two stations whose
longitude has the wrong sign, and Canary Wharf is the other: `0.01578` against an infobox reading
0°00′57″W, putting it 2.5km out in the river off Blackwall. Both are Elizabeth line stations NaPTAN
ships with the position left blank, so both are among the fourteen the override file still answers
for, and both are live in the feed.

## Why nothing caught it

- **The DTD had it right.** `BOND STREET EL … 15285 61810` unprojects to 51.51332,-0.14959, on
  Davies Street. `toStop` `Object.assign`s the override straight over it.
- **NaPTAN cannot rescue it.** Its rail records for BDS and CWX have no coordinate, which
  `NaptanSource` already skips over by name.
- **The bounds check cannot see it.** `BOUNDS` runs to 2.1°E. A London longitude with its sign lost
  is comfortably inside Great Britain, so only a lat/lon transposition — the TCR bug the spec was
  written for — lands somewhere the box notices.

## What this changes

Both signs are now negative, and `toStop` compares the two sources it has instead of assuming one.
Where an override and the grid reference disagree by more than 5km the DTD's position is kept and
the station is named on stderr; the name and the accessibility the override also carries still
apply, and a station the DTD could not locate has only the override, so it is taken as given.

5km sits above every honest disagreement: the grid reference is rounded to 100m and names a point
somewhere in the station, Birmingham New Street's is 1.3km from the platforms with the override in
the right, and the largest disagreement across all 2,764 stations both sources describe is 3.3km.
After this branch nothing trips it.

It did trip on a fixture: the CIF source spec's Tonbridge sat at easting 15862 rather than 15586,
28km away near Ashford, which is the same transposition in miniature. Corrected, and the override in
that test now sits 163m from the grid reference — which is the relationship the test is about.

## Not fixed here

`withStopPoints` spreads the boarding points off their parents before enrichment runs, and
`MutableFeed.stations` deliberately excludes children, so NaPTAN's coordinates never reach the
platform stops that `stop_times.txt` actually references. It makes no difference to Bond Street —
NaPTAN has nothing for it, so parent and children were equally wrong — but it means every platform
in the feed publishes the DTD position while its station publishes NaPTAN's. Worth its own issue.
