### PR TITLE
Make the boarding points after the stations are final

### DIFF
--- a/.changeset/boarding-points-after-enrichment.md
+++ b/.changeset/boarding-points-after-enrichment.md
@@ -1,0 +1,26 @@
+---
+"@gb-transit/gtfs": patch
+---
+
+Make the boarding points after the stations are final, not before.
+
+A station with platforms is published as a station row and a boarding point beneath each platform
+a train calls at, and each boarding point is a copy of its station with an id, a name and a platform
+code of its own. The copies were taken before the enrichers ran. An enricher is handed the stations
+alone — a source that knows where Clapham Junction is should not have to know it has sixteen
+platforms — so NaPTAN's surveyed position landed on the station and the copies underneath kept the
+DTD's rounded grid reference. Two rows for the same place, disagreeing, and `stop_times.txt`
+references the stale one.
+
+NaPTAN and the override file differ by more than 100 metres at 125 stations and by up to 3.2km, so
+that is the error a journey was planned from. It would have grown: retiring the override file leaves
+the boarding points on a grid reference rounded to 100 metres while their stations take NaPTAN.
+
+The stations are now enriched first and everything derived from them follows: the boarding points,
+and the headsigns, which named a train after the station as the DTD left it. Both now say what the
+station says. The boarding points are also derived from the schedules the feed publishes rather than
+from the schedules as they arrived, so a call dropped for referencing a station that is not in
+`stops.txt` no longer leaves a boarding point behind that nothing references.
+
+An extension still reads the whole feed, boarding points included. `MutableFeed.stations` is
+unchanged and enrichers see exactly what they saw before.

--- a/libs/gtfs/src/build/BuildFeed.spec.ts
+++ b/libs/gtfs/src/build/BuildFeed.spec.ts
@@ -346,6 +346,53 @@ describe("BuildFeed with an enricher", () => {
     expect(Object.keys(files["stops.txt"][0])).to.not.contain("located");
   });
 
+  /**
+   * What NaPTAN is: a position for the station and nothing about the platforms
+   * beneath it. A boarding point is where its station is, and it is what a stop
+   * time references, so an enricher that reached the station alone would have
+   * moved nothing a journey is planned from.
+   */
+  const mover: Enricher<null> = {
+    key: "TEST_MOVER",
+    dependsOn: [],
+    priority: 50,
+    async fetch() {
+      return null;
+    },
+    apply(feed) {
+      for (const station of feed.stations) {
+        feed.set(station, "stop_lat", 51.5, this);
+        feed.set(station, "stop_lon", -0.1, this);
+      }
+
+      return {enricher: this.key, matched: feed.stations.length, unmatched: 0, conflicts: 0};
+    }
+  };
+
+  it("puts a boarding point where the enricher put its station", async () => {
+    const {files} = await build(new FakeSource(feed(), [stop("TON", "TONBDG")]), [mover]);
+
+    expect(files["stops.txt"].map(s => [s.stop_id, s.stop_lat, s.stop_lon]))
+      .to.deep.equal([
+        ["9100TONBDG", 51.5, -0.1],
+        ["910GTONBDG", 51.5, -0.1]
+      ]);
+  });
+
+  it("names a boarding point after the station as the enricher left it", async () => {
+    const {files} = await build(new FakeSource(feed(), [stop("TON", "TONBDG")]), [namer]);
+
+    expect(files["stops.txt"].find(s => s.stop_id === "9100TONBDG").stop_name)
+      .to.equal("910GTONBDG renamed");
+  });
+
+  it("names a train after the station as the enricher left it", async () => {
+    const {files} = await build(new FakeSource(feed(), [stop("TON", "TONBDG"), stop("SEV", "SEVNOKS")]), [namer]);
+    const toTonbridge = files["trips.txt"].find(t => t.trip_id === "C00003_20240101_20240301");
+
+    expect(toTonbridge.trip_headsign).to.equal("910GTONBDG renamed");
+  });
+
   it("records who wrote what, and what the enricher could not place", async () => {
     const {files} = await build(new FakeSource(feed(), [stop("TON", "TONBDG"), stop("SEV", "SEVNOKS")]), [namer]);
     const [provenance] = files["provenance.json"];

--- a/libs/gtfs/src/build/BuildFeed.ts
+++ b/libs/gtfs/src/build/BuildFeed.ts
@@ -109,26 +109,31 @@ export class BuildFeed {
     // whether an unlocated station is published depends on whether anything
     // references it.
     const [sourceStops, fixedLinks] = await Promise.all([stopsQ, fixedLinksQ]);
-    // The boarding points are added before anything asks which stops the feed
-    // publishes, because a call references one of them rather than the station.
-    // Only the hierarchy is built here; a call's id is composed when
-    // stop_times.txt is written, so nothing upstream of this sees it.
-    const withChildren = withStopPoints(sourceStops, schedules);
-    const stops = locate(withChildren, referenced(schedules, fixedLinks));
+    const located = locate(sourceStops, referenced(schedules, fixedLinks));
     // Every index the build keeps is on the CRS code, because that is what a
     // schedule, an association and a fixed link name a station by.
-    const stations = new Map(
-      stops.filter(stop => stop.parent_station === null).map(stop => [stop.crs, stop])
-    );
-    const stopNames = map(stations, stop => stop.stop_name);
-    // Named after the stops are settled, because which stop a train divides at decides where the
-    // answer changes, and dropUnknownStops can move it.
-    const called = combinedHeadsigns(dropUnknownStops(schedules, new Set(stations.keys())), links, stopNames);
+    const stations = new Map(located.map(stop => [stop.crs, stop]));
+    // Dropped before the stations are enriched, because which stops the feed
+    // publishes is already settled and no enricher may add one.
+    const serving = dropUnknownStops(schedules, new Set(stations.keys()));
     // Only the stops are offered to an enricher. Trips and routes are streamed
     // straight to their files rather than held, and materialising 276,000 trips
     // to enrich a handful is the wrong trade until something needs it.
-    const feed = new MutableFeed(stops, [], []);
+    const feed = new MutableFeed(located, [], []);
     const reports = this.enrichers.length > 0 ? await enrich(feed, this.enrichers) : [];
+    // Everything a station decides is decided here, once it is final: what a
+    // train is named after, and the boarding points that carry its position.
+    const stopNames = map(stations, stop => stop.stop_name);
+    // Named after the stops are settled, because which stop a train divides at decides where the
+    // answer changes, and dropUnknownStops can move it.
+    const called = combinedHeadsigns(serving, links, stopNames);
+    // A boarding point is a copy of its station with an id, a name and a
+    // platform of its own, so it is made after the station has everything it is
+    // going to get. A call references one of these rather than the station, and
+    // a coordinate that reached the station alone would be a coordinate the
+    // stop times never see. The id is composed when stop_times.txt is written,
+    // so nothing upstream of here knows a station has platforms.
+    const stops = withStopPoints(located, called);
     // Written whole rather than through copy(): it is a document, and the CSV
     // writer turns its nested arrays into `[object Object]`.
     const provenanceP = reports.length > 0
@@ -138,11 +143,13 @@ export class BuildFeed {
       )
       : undefined;
 
-    // Extensions run after enrichment, so a file built out of the stops is
-    // built out of the stops as they will be published rather than as the DTD
-    // left them.
+    // Extensions run after enrichment and after the boarding points are made,
+    // so a file built out of the stops is built out of the stops as they will
+    // be published rather than as the DTD left them. A second view of the same
+    // stations, because the one the enrichers wrote through is deliberately the
+    // stations alone and an extension is entitled to the whole feed.
     const extended = this.extensions.length > 0
-      ? await extend(feed, this.extensions)
+      ? await extend(new MutableFeed(stops, [], []), this.extensions)
       : {files: [], reports: []};
     const extensionsP = extended.files.map(
       file => this.copy([...file.rows], {filename: file.filename, columns: file.columns}, file.key)


### PR DESCRIPTION
Found while investigating #187, and independent of the fix for it in #188.

## What was wrong

A station with platforms is published as a station row plus a boarding point beneath each platform a
train calls at, and each boarding point is a copy of its station with an id, a name and a platform
code of its own. `withStopPoints` took those copies at the top of the build, before `MutableFeed` was
even constructed.

`MutableFeed.stations` deliberately offers the stations alone — a source that knows where Clapham
Junction is should not have to know it has sixteen platforms — so NaPTAN corrected the station row
and nothing else. The copies underneath kept whatever the DTD and the override file had put in them
minutes earlier, and nothing re-synced them. Two rows for the same physical place, disagreeing, and
`stop_times.txt` references the stale one.

`docs/coordinate-review.md` is the size of it: NaPTAN and the override differ by more than 100m at
125 stations and by up to 3.2km. That is the error a journey was planned from. It would have grown —
retiring the override file under D7 leaves the boarding points on a grid reference rounded to 100m
while their stations take NaPTAN.

## What this changes

The order, and only the order. `locate` and the CRS index already filtered to stations, so they are
unaffected; the stations are enriched, and then everything derived from them follows:

- **the boarding points**, which now carry the position their station ended up with
- **the headsigns**, which named a train after the station as the DTD left it while the boarding
  points would now be named after the station as the enricher left it — the two have to agree
- **which boarding points exist**: they are derived from the schedules the feed publishes rather
  than from the schedules as they arrived, so a call dropped for naming a station that is not in
  `stops.txt` no longer leaves a boarding point behind that nothing references

An extension still reads the whole feed, boarding points included — it gets a second view over the
same stops, because the feed the enrichers write through is deliberately the stations alone.
`MutableFeed` itself is untouched and an enricher sees exactly what it saw before.

## Tests

Three new cases in `BuildFeed.spec`, each of which fails on master:

- an enricher that moves a station — what NaPTAN is — moves the boarding point with it
- a renamed station renames its boarding point
- a renamed station renames the trips headed for it

The rail golden runs no enrichers, so it does not move and there is no baseline to explain. Full
suite passes: 960 tests.

## Not fixed here

Every boarding point sits exactly on its station, which is right but not true — NaPTAN carries
platform records that could locate each one properly. Bigger job, and this is the precondition for
it either way.
