### PR TITLE
Serve the patterns a station at a time

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,6 +49,32 @@ jobs:
             -o apps/website/public/gtfs.zip
           ls -lh apps/website/public/gtfs.zip
 
+      # The site is built by astro rather than by the repository's `tsc -b`, so
+      # nothing here has needed the workspaces compiled until now. Splitting the
+      # patterns runs one of them.
+      - run: yarn build
+
+      # A release carries the patterns as one file because a release takes 1000
+      # assets and the network has 2,797 stations. Serving them is the other way
+      # round: a planner wants the station somebody is departing from and not the
+      # rest of the country, so the file is broken up here rather than rebuilt.
+      # Nothing is generated - the scan already ran, this is a read and a write.
+      #
+      # Not fatal if it is missing. A night whose scan did not finish publishes a
+      # feed without patterns, and the site should still go up.
+      - name: Publish the transfer patterns, a station at a time
+        run: |
+          if curl -fsSL --retry 3 --retry-delay 5 \
+            https://github.com/planarnetwork/gb-transit/releases/latest/download/transfer-patterns.br \
+            -o transfer-patterns.br
+          then
+            yarn tsx apps/transfer-patterns/src/index.ts split transfer-patterns.br \
+              --out apps/website/public/transfer-patterns
+            du -sh apps/website/public/transfer-patterns
+          else
+            echo "The latest release has no transfer-patterns.br, so the site goes up without them."
+          fi
+
       # The site is its own build now rather than part of the repository's
       # `tsc -b`, and it reads the latest release over the network to report what
       # the feed currently holds. A build that cannot reach it still deploys; it

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,9 @@ data/probe*
 # tracked - it holds the redirect that keeps the pre-redesign URL working.
 apps/website/public/gtfs.zip
 
+# The patterns, broken up a station at a time by the same workflow: 2,797 files
+# and 163MB, rebuilt from the release every time the site is.
+apps/website/public/transfer-patterns/
+
 # Downloaded by the validate job and by hand; 40MB and versioned by the workflow.
 gtfs-validator.jar

--- a/apps/transfer-patterns/README.md
+++ b/apps/transfer-patterns/README.md
@@ -22,6 +22,7 @@ Not published to npm; the nightly is the only caller.
 ```
 transfer-patterns plan <gtfs.zip> --out <shard.br> [options]
 transfer-patterns merge <shard.br>... --out <transfer-patterns.br>
+transfer-patterns split <transfer-patterns.br> --out <dir>
 ```
 
 `plan` scans the feed and writes the patterns it found, sorted and free of duplicates. `merge`
@@ -54,6 +55,35 @@ transfer-patterns merge shard-*.br --out transfer-patterns.br --meta meta.json
 | `--out <file>` | Where the patterns go. Required. |
 | `--shards <n>` | How many shards to expect. A merge short of one is missing that share of the network. |
 | `--meta <file>` | Also write how many patterns there are, as JSON. |
+
+### split
+
+| | |
+|---|---|
+| `--out <dir>` | Where the per station files go. Required. |
+
+## A station at a time
+
+A release takes 1000 assets and the network has 2,797 stations, so the release carries the patterns
+as one file. Reading them is the other way round: a planner wants the station somebody is departing
+from, not the rest of the country.
+
+`split` breaks the merged file up, one file per station, named for it — `LST.br`, `NRW.br`. The
+work is the planner's own `StationPatternFiles`, which writes a pattern under **both** of the
+stations it runs between, each time starting with the station whose file it is. So a query only
+ever fetches where it departs from, with no rule about which end to look under:
+
+```
+NRW.br    NRW AUD LST
+LST.br    LST AUD NRW
+```
+
+That doubles what is stored — 163MB against 57.6MB — which costs nothing when a reader only ever
+takes one of them. `NRW.br` is 100KB.
+
+The site publishes them under `/transfer-patterns/`, rebuilt from the release each time the Pages
+workflow runs, and `UrlPatternProvider` reads them straight from there. It is a plain `GET` per
+station, so a browser and a CDN can each make sense of it without being told anything.
 
 ## Dates
 

--- a/apps/transfer-patterns/package.json
+++ b/apps/transfer-patterns/package.json
@@ -34,7 +34,7 @@
     "@gb-transit/gtfs": "workspace:^",
     "@gb-transit/gtfs-loader": "workspace:^",
     "raptor-journey-planner": "^5.0.1",
-    "transfer-pattern-planner": "^2.3.0"
+    "transfer-pattern-planner": "^3.1.0"
   },
   "devDependencies": {
     "fflate": "^0.8.3",

--- a/apps/transfer-patterns/src/api.ts
+++ b/apps/transfer-patterns/src/api.ts
@@ -3,11 +3,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {loadGTFS} from "@gb-transit/gtfs-loader";
 import {createNetwork} from "raptor-journey-planner";
-import {checkCodeWidths} from "transfer-pattern-planner";
-import {TransferPatternMerge} from "transfer-pattern-planner/generate";
+import {PatternReader, checkCodeWidths} from "transfer-pattern-planner";
+import {StationPatternFiles, TransferPatternMerge} from "transfer-pattern-planner/generate";
+import type {WrittenFiles} from "transfer-pattern-planner/generate";
 import {checkWithinFeed, toISODate} from "./dates.js";
 import {kWayMerge} from "./merge/kWayMerge.js";
-import {readPatternFile, writePatternFile} from "./merge/patternFile.js";
+import {readPatternFile, readPatternLines, writePatternFile} from "./merge/patternFile.js";
 import {planOnWorkers} from "./plan/pool.js";
 import {readStations, shard} from "./plan/stations.js";
 
@@ -50,6 +51,15 @@ export interface MergeOptions {
    */
   readonly meta?: string;
 }
+
+export interface SplitOptions {
+  /** The pattern file to break up. */
+  readonly input: string;
+  /** Where the per station files go. Created if it is not there. */
+  readonly output: string;
+}
+
+export type SplitResult = WrittenFiles;
 
 export interface PatternResult {
   /** How many distinct patterns the file holds. */
@@ -181,6 +191,32 @@ export async function merge(options: MergeOptions): Promise<PatternResult> {
   }
 
   return result;
+}
+
+/**
+ * Break a pattern file into one file per station.
+ *
+ * A planner that knows where somebody is departing from reads one of these rather than all of them
+ * - tens of kilobytes against tens of megabytes. Writing them is the planner's own
+ * `StationPatternFiles`, which puts a pattern under both of the stations it runs between so that a
+ * query only ever needs the station it starts at, and takes out any station this run did not write
+ * so a directory cannot go on serving one the feed has dropped.
+ */
+export async function split(options: SplitOptions): Promise<SplitResult> {
+  const {input, output} = options;
+
+  await fs.promises.mkdir(output, {recursive: true});
+
+  const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "transfer-patterns-split-"));
+
+  try {
+    const files = new StationPatternFiles(workDir, new PatternReader());
+
+    return await files.write(readPatternLines(input), output);
+  }
+  finally {
+    await fs.promises.rm(workDir, {recursive: true, force: true});
+  }
 }
 
 /**

--- a/apps/transfer-patterns/src/help.ts
+++ b/apps/transfer-patterns/src/help.ts
@@ -4,6 +4,7 @@ transfer-patterns - build the transfer pattern file a journey planner reads
 
   transfer-patterns plan <gtfs.zip> --out <shard.br> [options]
   transfer-patterns merge <shard.br>... --out <transfer-patterns.br>
+  transfer-patterns split <transfer-patterns.br> --out <dir>
 
 plan finds every transfer pattern in a feed and writes them sorted, de-duplicated
 and brotli compressed. merge folds the shards of a run into one such file.
@@ -16,6 +17,9 @@ plan options:
   --workers <n>      Threads to scan on. Defaults to two fewer than the cores.
   --tmp <dir>        Where the workers' files go. Defaults to a temp directory,
                      which is removed afterwards.
+
+split writes one file per station, named for it, so a planner can read the
+patterns for a journey without reading the rest of the network.
 
 merge options:
   --out <file>       Where to write the patterns. Required.

--- a/apps/transfer-patterns/src/index.ts
+++ b/apps/transfer-patterns/src/index.ts
@@ -1,5 +1,5 @@
 import {option} from "@gb-transit/gtfs";
-import {merge, plan} from "./api.js";
+import {merge, plan, split} from "./api.js";
 import {parseDates, toISODate} from "./dates.js";
 import {showHelp} from "./help.js";
 import {parseShard, parseWorkers} from "./plan/stations.js";
@@ -24,6 +24,8 @@ async function main(argv: string[]): Promise<void> {
       return planFeed(argv, out(argv));
     case "merge":
       return mergeShards(argv, out(argv));
+    case "split":
+      return splitByStation(argv, out(argv));
     default:
       return showHelp();
   }
@@ -94,6 +96,23 @@ async function mergeShards(argv: string[], output: string): Promise<void> {
 
   console.log(
     `${patterns.toLocaleString()} patterns, ${megabytes(bytes)} in ${output}, ${elapsed(started)}`
+  );
+}
+
+async function splitByStation(argv: string[], output: string): Promise<void> {
+  const [input] = positionalArgs(argv);
+
+  if (input === undefined) {
+    throw new Error("Which file? transfer-patterns split <transfer-patterns.br> --out <dir>");
+  }
+
+  console.log(`Splitting ${input} into ${output}`);
+
+  const started = Date.now();
+  const {stations, bytes} = await split({input, output});
+
+  console.log(
+    `${stations.toLocaleString()} stations, ${megabytes(bytes)} in ${output}, ${elapsed(started)}`
   );
 }
 

--- a/apps/transfer-patterns/src/merge/patternFile.ts
+++ b/apps/transfer-patterns/src/merge/patternFile.ts
@@ -18,6 +18,14 @@ const QUALITY = 5;
  * Streamed. There are tens of millions of them and no reason to hold any two at once.
  */
 export function readPatternFile(file: string): AsyncIterable<string[]> {
+  return merged(decode(readPatternLines(file)));
+}
+
+/**
+ * The lines of a pattern file, still front coded, for a reader that wants them as they were
+ * written.
+ */
+export function readPatternLines(file: string): AsyncIterable<string> {
   // pipeline rather than pipe, which does not forward an error from the source.
   const decompressed = zlib.createBrotliDecompress();
   const done = pipeline(fs.createReadStream(file), decompressed);
@@ -26,7 +34,7 @@ export function readPatternFile(file: string): AsyncIterable<string[]> {
     crlfDelay: Number.POSITIVE_INFINITY
   });
 
-  return merged(decode(lines), done);
+  return merged(lines, done);
 }
 
 /**
@@ -55,13 +63,10 @@ async function* decode(lines: AsyncIterable<string>): AsyncGenerator<string[]> {
  * The patterns, or whatever stopped the stream that was carrying them. A reader ends quietly when
  * its input is destroyed, which would otherwise make a failed read a short file.
  */
-async function* merged(
-  patterns: AsyncIterable<string[]>,
-  done: Promise<void>
-): AsyncGenerator<string[]> {
-  const failed = done.then(() => undefined, (err: Error) => err);
+async function* merged<T>(items: AsyncIterable<T>, done?: Promise<void>): AsyncGenerator<T> {
+  const failed = done?.then(() => undefined, (err: Error) => err);
 
-  yield* patterns;
+  yield* items;
 
   const err = await failed;
 

--- a/apps/transfer-patterns/test/patterns.spec.mts
+++ b/apps/transfer-patterns/test/patterns.spec.mts
@@ -5,7 +5,11 @@ import {execFile} from "node:child_process";
 import {promisify} from "node:util";
 import {zipSync, strToU8} from "fflate";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
-import {PatternLoader, StopTable, loadGtfs} from "transfer-pattern-planner";
+import * as readline from "node:readline";
+import * as zlib from "node:zlib";
+import {Readable} from "node:stream";
+import {PatternLoader, PatternReader, StopTable, loadGtfs} from "transfer-pattern-planner";
+import {DirectoryPatternProvider} from "transfer-pattern-planner/node";
 import {readPatternFile} from "../src/merge/patternFile.js";
 
 const run = promisify(execFile);
@@ -212,6 +216,49 @@ describe("transfer-patterns", () => {
     // Ayton to Deeton has to change at Ceeton; Ayton to Ceeton does not have to change at all.
     expect(named("AAA", "DDD")).to.deep.equal(["AAA CCC DDD"]);
     expect(named("AAA", "CCC")).to.deep.equal(["AAA CCC"]);
+  }, 240_000);
+
+  it("splits into a file per station, each holding the journeys that depart it", async () => {
+    const whole = path.join(workDir, "whole-for-split.br");
+    const stations = path.join(workDir, "stations");
+
+    await transferPatterns("plan", feed, "--dates", "2026-06-03", "--workers", "2", "--out", whole);
+    await transferPatterns("split", whole, "--out", stations);
+
+    const provider = new DirectoryPatternProvider(stations);
+    const patternsAt = async (station: string) => {
+      const bytes = await provider.get(station);
+
+      if (bytes === undefined) {
+        return [];
+      }
+
+      const lines = readline.createInterface({
+        input: Readable.from([Buffer.from(bytes)]).pipe(zlib.createBrotliDecompress())
+      });
+      const found: string[] = [];
+
+      for await (const pattern of new PatternReader().read(lines)) {
+        found.push(pattern.join(" "));
+      }
+
+      return found;
+    };
+
+    // A pattern is written under both of its ends, each time starting with the station whose file
+    // it is, so a planner only ever fetches the station somebody is departing from.
+    expect(await patternsAt("AAA")).to.contain("AAA CCC DDD");
+    expect(await patternsAt("DDD")).to.contain("DDD CCC AAA");
+
+    // Every line of a station's file begins with that station.
+    for (const station of ["AAA", "BBB", "CCC", "DDD"]) {
+      const patterns = await patternsAt(station);
+
+      expect(patterns, station).not.to.be.empty;
+      expect(patterns.every(p => p.startsWith(station)), station).to.be.true;
+    }
+
+    expect(await provider.get("BAD")).to.be.undefined;
   }, 240_000);
 
   it("refuses a date the feed does not cover", async () => {

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@astrojs/markdown-satteri": "^0.4.0",
     "@astrojs/mdx": "^8.0.0",
+    "@gb-transit/gtfs-loader": "workspace:^",
     "astro": "^7.3.1"
   }
 }

--- a/apps/website/src/components/Footer.astro
+++ b/apps/website/src/components/Footer.astro
@@ -11,6 +11,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       </div>
       <nav aria-label="Footer">
         <a href={`${base}/feeds/`}>Feeds</a>
+        <a href={`${base}/feeds/transfer-patterns/`}>Transfer patterns</a>
         <a href={`${base}/feeds/using-this-data/`}>Using this data</a>
         <a href={`${base}/tools/`}>Tools</a>
         <a href={GITHUB}>{OWNER}/{REPO}</a>

--- a/apps/website/src/components/Header.astro
+++ b/apps/website/src/components/Header.astro
@@ -12,6 +12,7 @@ const here = Astro.url.pathname;
 
 const links = [
   {href: "/feeds/", label: "Feeds"},
+  {href: "/feeds/transfer-patterns/", label: "Transfer patterns"},
   {href: "/feeds/using-this-data/", label: "Using this data"},
   {href: "/tools/", label: "Tools"}
 ];

--- a/apps/website/src/pages/feeds/index.astro
+++ b/apps/website/src/pages/feeds/index.astro
@@ -89,6 +89,18 @@ const assets = [
   </section>
 
   <section class="shell section">
+    <h2 class="h2 h2--sm">Not a feed, but published with them</h2>
+    <p style="margin: 14px 0 20px; font-size: 15.5px; color: var(--ink-body); max-width: 70ch;">
+      Transfer patterns are every route through the network, found in advance, so a journey planner
+      reads them instead of searching. One file for the country, or one per station &mdash; a query
+      only ever fetches where it departs from.
+    </p>
+    <p style="margin: 0; font-size: 15px;">
+      <a href={`${base}/feeds/transfer-patterns/`}>Transfer patterns &rarr;</a>
+    </p>
+  </section>
+
+  <section class="shell section">
     <h2 class="h2 h2--sm">What else is on a release</h2>
     <p style="margin: 14px 0 20px; font-size: 15.5px; color: var(--ink-body); max-width: 70ch;">
       Four JSON files, as separate assets rather than inside the zips, because they describe the

--- a/apps/website/src/pages/feeds/transfer-patterns.astro
+++ b/apps/website/src/pages/feeds/transfer-patterns.astro
@@ -1,0 +1,159 @@
+---
+import Base from "../../layouts/Base.astro";
+import Terminal from "../../components/Terminal.astro";
+import {latest} from "../../feed.js";
+import {PATTERNS_PATH, byLetter, kilobytes, patternStations} from "../../patterns.js";
+import {RELEASE, npm, source} from "../../site.js";
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const meta = await latest();
+const stations = await patternStations();
+const letters = byLetter(stations);
+const total = stations.reduce((bytes, station) => bytes + station.bytes, 0);
+---
+<Base
+  title="Transfer patterns"
+  description="Every route through the GB rail network, found in advance so a journey planner does not have to search for them. One file for the lot, or one per station."
+>
+  <div class="shell page-head">
+    <p class="crumb"><a href={`${base}/feeds/`}>Feeds</a></p>
+    <h1>Transfer patterns.</h1>
+    <p class="lede">
+      Every sequence of stations a journey can be made of, found in advance. A planner reads them
+      instead of searching the network, which is what makes it answer in milliseconds.
+    </p>
+  </div>
+
+  <section class="shell section--tight" style="padding-top: clamp(32px, 4vw, 44px);">
+    <div class="cards cards--wide" style="margin-top: 0;">
+      <div class="card">
+        <div class="eyebrow">The whole network</div>
+        <div>
+          <h3 class="card__title--display">One file</h3>
+          <p>
+            Every pattern, sorted and front coded, once under whichever of its two ends sorts first.
+            What you want if you are planning journeys across the country, or want to hold the lot
+            in memory.
+          </p>
+        </div>
+        <div class="card__foot">
+          <a class="btn btn--signal" href={`${RELEASE}/transfer-patterns.br`}>
+            transfer-patterns.br &rarr;
+          </a>
+          <p style="margin: 12px 0 0; font-size: 15px; color: var(--ink-quiet);">
+            On the latest release, beside the feed it describes.
+          </p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="eyebrow">One station</div>
+        <div>
+          <h3 class="card__title--display">A file each</h3>
+          <p>
+            The same patterns, written under both of the stations they run between, so a query only
+            ever fetches where it departs from. Tens of kilobytes rather than tens of megabytes.
+          </p>
+        </div>
+        <div class="card__foot">
+          {stations.length > 0
+            ? <a class="btn btn--signal" href="#stations">
+                {stations.length.toLocaleString()} stations &darr;
+              </a>
+            : <p style="margin: 0; font-size: 15px; color: var(--ink-quiet);">
+                Published once a nightly feed carries them.
+              </p>}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="shell section">
+    <h2 class="h2 h2--sm">What a pattern is</h2>
+    <p style="margin: 14px 0 18px; font-size: 15.5px; color: var(--ink-body); max-width: 70ch;">
+      The stations a journey calls at, three characters each, nothing between them. One line is one
+      pattern.
+    </p>
+    <Terminal lines={[
+      "NRWLST            Norwich to Liverpool Street, direct",
+      "NRWCBGLST         changing at Cambridge",
+      "NRWCBGELYLST      changing at Cambridge and Ely"
+    ]} />
+    <p style="margin: 18px 0 0; font-size: 15.5px; color: var(--ink-body); max-width: 70ch;">
+      The codes are the <code>stop_code</code> of the feed &mdash; CRS codes &mdash; so the two are
+      read together: <code>stops.txt</code> is what turns <code>NRW</code> back into Norwich and
+      into somewhere with a platform and a position. Patterns are found a day at a time and the
+      published file holds a week of them, so it covers every shape of service the timetable has.
+      Sorting puts patterns beginning the same way together, so a line records only what it adds to
+      the one above it, and the whole thing is brotli compressed.
+    </p>
+    <p style="margin: 18px 0 0; font-size: 15.5px; color: var(--ink-body); max-width: 70ch;">
+      They are built after the feed they describe is published, so a release without them is a night
+      whose scan did not finish rather than a feed with something wrong.
+      <a href={`${base}/feeds/using-this-data/#the-transfer-patterns`}>Using this data</a> says more,
+      and <a href={npm("transfer-pattern-planner")}><code>transfer-pattern-planner</code></a> both
+      writes them and reads them back.
+    </p>
+  </section>
+
+  <section class="shell section">
+    <h2 class="h2 h2--sm">Reading one station</h2>
+    <p style="margin: 14px 0 18px; font-size: 15.5px; color: var(--ink-body); max-width: 70ch;">
+      Each file is named for its station and holds every pattern departing it, so nothing has to
+      keep an index of where they are. It is a plain <code>GET</code>, which a browser and a cache
+      can each make sense of on their own.
+    </p>
+    <Terminal lines={[
+      `curl -O https://planarnetwork.github.io${PATTERNS_PATH}/NRW.br`
+    ]} />
+  </section>
+
+  {stations.length > 0 && (
+    <section class="shell section section--last" id="stations">
+      <h2 class="h2 h2--sm">Every station</h2>
+      <p style="margin: 14px 0 18px; font-size: 15.5px; color: var(--ink-body); max-width: 70ch;">
+        {stations.length.toLocaleString()} of them, {kilobytes(total / stations.length)} each on
+        average, from the feed on the most recent release
+        {meta?.feed_version && <> &mdash; <code>{meta.feed_version}</code></>}.
+      </p>
+      <p style="margin: 0 0 22px; font-size: 15px;">
+        {letters.map(([letter], index) => (
+          <>
+            {index > 0 && " · "}
+            <a href={`#letter-${letter}`}>{letter}</a>
+          </>
+        ))}
+      </p>
+      {letters.map(([letter, group]) => (
+        <div style="margin-bottom: 26px;" id={`letter-${letter}`}>
+          <h3 class="h3" style="margin: 0 0 10px;">{letter}</h3>
+          <div class="table-scroll">
+            <table>
+              <thead>
+                <tr><th>station</th><th>code</th><th>patterns</th></tr>
+              </thead>
+              <tbody>
+                {group.map(station => (
+                  <tr>
+                    <td>{station.name ?? <span style="color: var(--ink-quiet);">&mdash;</span>}</td>
+                    <td>
+                      <a href={`${PATTERNS_PATH}/${station.code}.br`}>
+                        <code>{station.code}.br</code>
+                      </a>
+                    </td>
+                    <td>{kilobytes(station.bytes)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+      <p style="margin: 20px 0 0; font-size: 14.5px; color: var(--ink-quiet); max-width: 70ch;">
+        Read from the directory the build published rather than written here, so this cannot offer a
+        station whose file is not there. The split itself is
+        <a href={source("apps/transfer-patterns/README.md")}> <code>transfer-patterns split</code></a>,
+        run over the release each time this site is built.
+      </p>
+    </section>
+  )}
+</Base>

--- a/apps/website/src/patterns.ts
+++ b/apps/website/src/patterns.ts
@@ -1,0 +1,95 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {readFeedRows} from "@gb-transit/gtfs-loader";
+
+/**
+ * A station somebody can fetch the patterns of.
+ */
+export interface PatternStation {
+  /** The CRS code, which is what the file is named after. */
+  code: string;
+  /** What to call it, where the feed says. */
+  name?: string;
+  /** How large its file is. */
+  bytes: number;
+}
+
+/**
+ * Where the Pages workflow leaves what it publishes. Both are read at build time and neither is in
+ * the repository: the feed is downloaded from the release and the patterns are broken out of it.
+ *
+ * From the working directory rather than from `import.meta.url`, which points into the bundle astro
+ * builds this module into rather than at the file it was written in.
+ */
+const PUBLIC = path.join(process.cwd(), "public");
+const DIRECTORY = path.join(PUBLIC, "transfer-patterns");
+const FEED = path.join(PUBLIC, "gtfs.zip");
+
+/** Where a browser fetches them from, which is the same directory served. */
+export const PATTERNS_PATH = "/transfer-patterns";
+
+/**
+ * Every station the split wrote a file for, named where the feed can say.
+ *
+ * Read from the directory rather than from a list, so the page cannot offer a station whose file is
+ * not there. A build with no patterns beside it - anybody's checkout, or a night whose scan did not
+ * finish - gets an empty list and a page that says so, which is better than a page of links that
+ * 404.
+ */
+export async function patternStations(): Promise<PatternStation[]> {
+  if (!fs.existsSync(DIRECTORY)) {
+    return [];
+  }
+
+  const names = await stationNames();
+  const stations = fs.readdirSync(DIRECTORY)
+    .filter(file => file.endsWith(".br"))
+    .map(file => {
+      const code = file.slice(0, -".br".length);
+
+      return {code, name: names.get(code), bytes: fs.statSync(path.join(DIRECTORY, file)).size};
+    });
+
+  return stations.sort((a, b) => a.code.localeCompare(b.code));
+}
+
+/**
+ * The station names of the feed published beside these, by CRS code.
+ *
+ * A three letter code is not a station to most people, and the feed is already here to be
+ * downloaded. Absent where it is not, which only costs the page its names.
+ */
+async function stationNames(): Promise<Map<string, string>> {
+  if (!fs.existsSync(FEED)) {
+    return new Map();
+  }
+
+  const {"stops.txt": stops} = await readFeedRows(fs.createReadStream(FEED), ["stops.txt"]);
+
+  return new Map(stops
+    .filter(stop => stop.stop_code !== undefined && !stop.parent_station)
+    .map(stop => [stop.stop_code as string, stop.stop_name as string]));
+}
+
+/**
+ * The stations under each letter they begin with, for a list of 2,797 of them that somebody has to
+ * be able to find their way around.
+ */
+export function byLetter(stations: readonly PatternStation[]): [string, PatternStation[]][] {
+  const letters = new Map<string, PatternStation[]>();
+
+  for (const station of stations) {
+    const letter = station.code.slice(0, 1).toUpperCase();
+
+    letters.set(letter, [...(letters.get(letter) ?? []), station]);
+  }
+
+  return [...letters].sort(([a], [b]) => a.localeCompare(b));
+}
+
+/**
+ * A size somebody can read, which for these is always kilobytes.
+ */
+export function kilobytes(bytes: number): string {
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,6 +920,7 @@ __metadata:
   dependencies:
     "@astrojs/markdown-satteri": "npm:^0.4.0"
     "@astrojs/mdx": "npm:^8.0.0"
+    "@gb-transit/gtfs-loader": "workspace:^"
     astro: "npm:^7.3.1"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,7 +907,7 @@ __metadata:
     "@gb-transit/gtfs-loader": "workspace:^"
     fflate: "npm:^0.8.3"
     raptor-journey-planner: "npm:^5.0.1"
-    transfer-pattern-planner: "npm:^2.3.0"
+    transfer-pattern-planner: "npm:^3.1.0"
     typescript: "npm:7.0.2"
   bin:
     transfer-patterns: bin/transfer-patterns.sh
@@ -4523,13 +4523,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"transfer-pattern-planner@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "transfer-pattern-planner@npm:2.3.0"
+"transfer-pattern-planner@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "transfer-pattern-planner@npm:3.1.0"
   dependencies:
     "@gb-transit/gtfs-loader": "npm:^1.1.0"
     raptor-journey-planner: "npm:^5.0.1"
-  checksum: 10c0/b15acba6d8dddbf7946d3edc6f2d9a2a07a8ae7e9637d3890558ee0a205c252f3a87a3c01f3ecf607e176f3c1a7882c99f85747d6a571807550eb63fd77f1832
+  checksum: 10c0/d4d0c9ba85b07d31e7471018752c876a01305ec1b1321496a7bca6d8c638a6a34bdcc0d0d824fda4f748c5abfcb294b9f2c084ac583b173013a8f2072f4d289b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
A release takes 1000 assets and the network has 2,797 stations, so the release carries the patterns as one file. Reading them is the other way round: a planner wants the station somebody is departing from, not the rest of the country.

The Pages workflow already runs after a feed is published, so this takes the file the release carries and breaks it up there. **Nothing is regenerated** — the scan already ran; this is a read and a write, and it takes 3m30s.

## transfer-pattern-planner 3.1.0 does the work

`StationPatternFiles` writes a pattern under **both** of the stations it runs between, each time starting with the station whose file it is:

```
NRW.br    NRW AUD LST
LST.br    LST AUD NRW
```

So a query only ever fetches where it departs from, with no rule about which end to look under. It also removes stations a run did not write, so a directory cannot go on serving one the feed has since dropped.

I had written a splitter by hand before 3.1.0 landed and threw it away — it stored each pattern once under the alphabetically-first end, which is 84.6MB instead of 163MB but makes a client fetch the *destination's* file for half its queries. Doubling the storage is the better trade when a reader only ever takes one file.

## Measured on the real 57,200,119-pattern file

| | |
|---|---|
| Files | 2,797 |
| Total | 163MB (against 57.6MB for the single file) |
| `NRW.br` | 100KB |
| `PAD.br` | 29,344 patterns |
| Split time | 3m30s, 303MB peak |

Verified with the library's own reader: `DirectoryPatternProvider` + `PatternReader` gives 19 patterns for NRW→LST out of `NRW.br` and the same 19 reversed out of `LST.br`, and every line of a station's file begins with that station.

## Also here

- **Upgrade to 3.1.0** from 2.3.0. A major bump, but nothing this app uses broke — the renames (`TransferTree` → `TransferTreeRepository`, `readPatterns` → `PatternReader`) are all on parts it does not touch.
- `pages.yml` gains a `yarn build`, since the site is an astro build and nothing there had needed the workspaces compiled until now.
- The directory is gitignored, like `gtfs.zip` beside it. Pages deploys by artifact, so none of it reaches git history.

## The risk I cannot test from here

GitHub Pages has a **10-minute deployment timeout**, and this adds 163MB in 2,797 files on top of the 20MB `gtfs.zip` the site already ships. Well under the 1GB site limit, but I have no way to know how `upload-pages-artifact` and `deploy-pages` handle that file count until it runs.

It will run on its own after the next nightly, since `pages.yml` triggers on "Nightly feed" completing. If it does time out, that is a problem to solve on its own terms rather than by serving something other than a file per station.

Checked: `npm test` equivalent — 1055 tests, typecheck, and `YARN_ENABLE_HARDENED_MODE=1 yarn install --immutable`, which is what CI actually runs.

