### PR TITLE
Let a merge take a feed with buses in it

### DIFF
--- a/.changeset/stream-the-stop-times.md
+++ b/.changeset/stream-the-stop-times.md
@@ -1,0 +1,33 @@
+---
+"gtfsmerge": minor
+---
+
+Read a feed's stop times in a pass of their own, rather than holding them.
+
+A merge held every input feed whole, and `stop_times.txt` is almost all of a feed. Held the way the
+merge held them, one national bus feed's 59,129,908 calls cost 18.0GB against 0.7GB for the
+1,854,991 rows of everything else — 96% of the memory for one file. Merging that feed with the
+published rail one peaked at 22.1GB and ended, at the 8GB `bin/gtfsmerge.sh` allows:
+
+```
+Loading rail.zip / Processing rail.zip / Loading bus.zip
+FATAL ERROR: Ineffective mark-compacts near heap limit - JavaScript heap out of memory
+```
+
+The order the merge already worked in is why they need not be held at all. Nothing can be done with
+a call until its trip has been numbered, and the trips are numbered from the routes and calendars;
+nothing needs the call afterwards. So `readMergeInput` now reads everything but the stop times, and
+`stopTimesOf` reads the file again for those alone, handing each call to `StopTimesMerger` to remap
+and write as it arrives.
+
+The second read is what this costs, and it is a read of a file rather than a copy of it in memory.
+
+`GTFSOutput.write` takes a `StopTimeReader` alongside the feed, and `GTFSZip` no longer has a
+`stopTimes` field. Anything embedding gtfsmerge rather than running it will notice; the CLI is
+unchanged.
+
+Backpressure moved with it. The rows of a chunk arrive from a synchronous parser that cannot be made
+to wait for a writer partway through, so a chunk's calls are collected and written between one chunk
+of the zip and the next, which is where the reader can be paused. A feed's last calls arrive after
+its last chunk, as the inflater and the parser give up what they were holding, and are written after
+the read rather than lost.

--- a/.changeset/stream-the-zip.md
+++ b/.changeset/stream-the-zip.md
@@ -1,0 +1,31 @@
+---
+"@gb-transit/gtfs-output": minor
+---
+
+Write the feed's zip as a stream, so a feed larger than 2GB can be published.
+
+`writeZip` used adm-zip, which assembles the whole archive in memory and refuses any entry over
+2GB. A rail feed is nowhere near that. A feed with bus stop times in it is: merging
+`gtfs.zip` with the Bus Open Data Service's national feed produces a `stop_times.txt` of 2.96GB, and
+the merge ended
+
+```
+Writing merged.zip
+File size (2955798571) is greater than 2 GiB
+```
+
+after three minutes of work, with the feed built and nowhere to put it.
+
+It now streams each file into the archive through fflate, which the reader and four other packages
+here already use. Writing the 3.05GB feed above takes 81 seconds and 116MB of memory, and the result
+is a valid archive whose contents are byte for byte the directory it came from.
+
+Two limits remain, and both are now explicit rather than discovered:
+
+- fflate writes an entry's size into four bytes and does not check that it fits, so a file over 4GB
+  would produce an archive that decompresses to the wrong thing with no error at all. The sizes are
+  checked before anything is written, and a file too large to describe fails the build with the name
+  and the size in the message. zip64, which fflate does not write, is what lifts this.
+- Every entry is now stamped with a fixed date rather than the modification time of the file it came
+  from, so two builds of the same feed produce the same bytes. They did not before: the files a feed
+  is built from are written afresh by every build.

--- a/apps/gtfsmerge/src/gtfs/FeedIndex.ts
+++ b/apps/gtfsmerge/src/gtfs/FeedIndex.ts
@@ -1,9 +1,10 @@
 import {
-  AgencyRow, CalendarDateRow, CalendarRow, FixedLinkRow, RouteRow, StopID, StopRow, StopTimeRow,
+  AgencyRow, CalendarDateRow, CalendarRow, FixedLinkRow, RouteRow, StopID, StopRow,
   TransferRow, TransferType, TripRow
 } from "@gb-transit/gtfs-schema";
 import {readFeed} from "@gb-transit/gtfs-loader";
 import * as fs from "fs";
+import {StopTimeReader} from "./merger/StopTimesMerger";
 
 /**
  * One input feed, in memory, in the shape the mergers consume.
@@ -13,7 +14,6 @@ export interface GTFSZip {
   transfers: TransferRow[];
   calendars: CalendarRow[];
   calendarDates: Record<string, CalendarDateRow[]>;
-  stopTimes: StopTimeRow[];
   routes: RouteRow[];
   agencies: AgencyRow[];
   stops: StopRow[];
@@ -32,7 +32,7 @@ export class FeedIndex {
 
   private readonly transfers: Record<string, TransferRow> = {};
   private readonly result: GTFSZip = {
-    trips: [], transfers: [], calendars: [], calendarDates: {}, stopTimes: [], routes: [],
+    trips: [], transfers: [], calendars: [], calendarDates: {}, routes: [],
     agencies: [], stops: [], parentStops: {}
   };
 
@@ -43,16 +43,6 @@ export class FeedIndex {
 
   public trip(row: TripRow): void {
     this.result.trips.push(row);
-  }
-
-  /**
-   * A call with only one of its times is not a call anything can plan through.
-   */
-  public stopTime(row: StopTimeRow): void {
-    if (row.departure_time && row.arrival_time) {
-      row.stop_id = this.stopPrefix + row.stop_id;
-      this.result.stopTimes.push(row);
-    }
   }
 
   public route(row: RouteRow): void {
@@ -145,11 +135,16 @@ export class FeedIndex {
 }
 
 /**
- * Read one input feed.
+ * Read one input feed, apart from its stop times.
  *
  * The rows are copied out because the reader hands back the same object every
  * time - it is reading a file that may be three million rows and does not
  * allocate one per row.
+ *
+ * The stop times are left for `stopTimesOf` and a second pass over the file.
+ * Everything here is needed before a single call can be written - a call is
+ * indexed against its trip, and a trip against its route and its calendar - and
+ * everything here put together is a fortieth of what the calls cost to hold.
  */
 export async function readMergeInput(
   file: string,
@@ -160,7 +155,6 @@ export async function readMergeInput(
 
   await readFeed(fs.createReadStream(file), {
     "trips.txt": row => index.trip({...row}),
-    "stop_times.txt": row => index.stopTime({...row}),
     "routes.txt": row => index.route({...row}),
     "stops.txt": row => index.stop({...row}),
     "agency.txt": row => index.agency({...row}),
@@ -171,4 +165,47 @@ export async function readMergeInput(
   });
 
   return index.results();
+}
+
+/**
+ * The stop times of one feed, in a pass of their own.
+ *
+ * Nothing is kept: each call is handed straight to whoever asked for it, and the
+ * merger writes it and lets it go. A second read of the file is what that costs,
+ * and the file is read rather than held.
+ *
+ * A call with only one of its times is not a call anything can plan through, so
+ * it never leaves here.
+ */
+export function stopTimesOf(file: string, stopPrefix = ""): StopTimeReader {
+  return async (onRow, betweenChunks) => {
+    await readFeed(pausing(file, betweenChunks), {
+      "stop_times.txt": row => {
+        if (row.departure_time && row.arrival_time) {
+          row.stop_id = stopPrefix + row.stop_id;
+
+          onRow(row);
+        }
+      }
+    });
+  };
+}
+
+/**
+ * The file, a chunk at a time, giving the reader's consumer a turn between one
+ * chunk and the next.
+ *
+ * The rows of a chunk arrive from a synchronous parser, which cannot be made to
+ * wait for a writer partway through. Here it can: the reader asks for the next
+ * chunk, and does not get one until the calls from the last chunk are written.
+ */
+async function* pausing(
+  file: string,
+  betweenChunks: () => Promise<void>
+): AsyncIterable<Uint8Array> {
+  for await (const chunk of fs.createReadStream(file)) {
+    yield chunk;
+
+    await betweenChunks();
+  }
 }

--- a/apps/gtfsmerge/src/gtfs/GTFSOutput.ts
+++ b/apps/gtfsmerge/src/gtfs/GTFSOutput.ts
@@ -1,7 +1,7 @@
 import {GTFSZip} from "./FeedIndex";
 import {CalendarMerger} from "./merger/CalendarMerger";
 import {StopsAndTransfersMerger} from "./merger/StopsAndTransfersMerger";
-import {StopTimesMerger} from "./merger/StopTimesMerger";
+import {StopTimeReader, StopTimesMerger} from "./merger/StopTimesMerger";
 import {TripsMerger} from "./merger/TripsMerger";
 import {GenericMerger} from "./merger/GenericMerger";
 import {RouteMerger} from "./merger/RouteMerger";
@@ -27,15 +27,19 @@ export class GTFSOutput {
    * the trips are indexed against, the trips give the map the stop times and the
    * couplings are indexed against, and the stop times say which stops anything
    * actually calls at.
+   *
+   * The stop times arrive as a reader rather than as rows, because that order is
+   * also the reason they need not be held: nothing can be done with a call until
+   * its trip has been numbered, and nothing needs it afterwards.
    */
-  public async write(gtfs: GTFSZip): Promise<void> {
+  public async write(gtfs: GTFSZip, stopTimes: StopTimeReader): Promise<void> {
     const [routeIdMap, serviceIdMap] = await Promise.all([
       this.routes.write(gtfs.routes),
       this.calendar.write(gtfs.calendars, gtfs.calendarDates)
     ]);
 
     const tripIdMap = await this.trips.write(gtfs.trips, serviceIdMap, routeIdMap);
-    const usedStops = await this.stopTimes.write(gtfs.stopTimes, tripIdMap, gtfs.parentStops);
+    const usedStops = await this.stopTimes.write(stopTimes, tripIdMap, gtfs.parentStops);
 
     await Promise.all([
       this.stopsAndTransfers.write(

--- a/apps/gtfsmerge/src/gtfs/MergeCommand.ts
+++ b/apps/gtfsmerge/src/gtfs/MergeCommand.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import {deliverFeed} from "@gb-transit/gtfs-output";
-import {readMergeInput} from "./FeedIndex";
+import {readMergeInput, stopTimesOf} from "./FeedIndex";
 import {GTFSOutputFactory} from "./GTFSOutputFactory";
 
 /**
@@ -29,7 +29,7 @@ export class MergeCommand {
       const gtfs = await readMergeInput(input, stopPrefix, filterDatesBefore);
 
       console.log("Processing " + input);
-      await output.write(gtfs);
+      await output.write(gtfs, stopTimesOf(input, stopPrefix));
     }
 
     await output.end();

--- a/apps/gtfsmerge/src/gtfs/merger/StopTimesMerger.spec.ts
+++ b/apps/gtfsmerge/src/gtfs/merger/StopTimesMerger.spec.ts
@@ -1,14 +1,34 @@
 import {describe, it, expect} from "vitest";
 import {StopTimeRow} from "@gb-transit/gtfs-schema";
-import {StopTimesMerger} from "./StopTimesMerger";
+import {StopTimeReader, StopTimesMerger} from "./StopTimesMerger";
 import {collect, stopTime} from "./Fixtures";
+
+/**
+ * The rows of a feed, offered the way the reader offers them: one chunk at a
+ * time, the same row object reused throughout, and a pause between chunks.
+ */
+function reading(chunks: StopTimeRow[][]): StopTimeReader {
+  return async (onRow, betweenChunks) => {
+    const reused = {} as StopTimeRow;
+
+    for (const chunk of chunks) {
+      for (const row of chunk) {
+        onRow(Object.assign(reused, row));
+      }
+
+      await betweenChunks();
+    }
+  };
+}
+
+const asRows = (rows: StopTimeRow[]): StopTimeReader => reading([rows]);
 
 describe("StopTimesMerger", () => {
 
   it("remaps the trip and reports the stops that were called at", async () => {
     const stopTimes = collect<StopTimeRow>();
     const used = await new StopTimesMerger(stopTimes)
-      .write([stopTime("t1", "s1", 1)], {t1: "42"}, {});
+      .write(asRows([stopTime("t1", "s1", 1)]), {t1: "42"}, {});
 
     expect(stopTimes.rows[0]).to.include({trip_id: "42", stop_id: "s1"});
     expect(used).to.deep.equal({s1: true});
@@ -17,7 +37,7 @@ describe("StopTimesMerger", () => {
   it("calls at the station rather than the platform", async () => {
     const stopTimes = collect<StopTimeRow>();
     const used = await new StopTimesMerger(stopTimes)
-      .write([stopTime("t1", "platform", 1)], {t1: "1"}, {platform: "station"});
+      .write(asRows([stopTime("t1", "platform", 1)]), {t1: "1"}, {platform: "station"});
 
     expect(stopTimes.rows[0].stop_id).to.equal("station");
     expect(used).to.deep.equal({station: true});
@@ -25,10 +45,110 @@ describe("StopTimesMerger", () => {
 
   it("drops the stop times of a trip that was dropped", async () => {
     const stopTimes = collect<StopTimeRow>();
-    const used = await new StopTimesMerger(stopTimes).write([stopTime("gone", "s1", 1)], {}, {});
+    const used = await new StopTimesMerger(stopTimes)
+      .write(asRows([stopTime("gone", "s1", 1)]), {}, {});
 
     expect(stopTimes.rows).to.deep.equal([]);
     expect(used).to.deep.equal({});
+  });
+
+  /**
+   * The reader hands back the same object for every row, so a call held past the
+   * one after it is the one after it.
+   */
+  it("keeps each call as it was when it arrived", async () => {
+    const stopTimes = collect<StopTimeRow>();
+
+    await new StopTimesMerger(stopTimes).write(
+      asRows([stopTime("t1", "s1", 1), stopTime("t1", "s2", 2), stopTime("t1", "s3", 3)]),
+      {t1: "1"},
+      {}
+    );
+
+    expect(stopTimes.rows.map(row => row.stop_id)).to.deep.equal(["s1", "s2", "s3"]);
+    expect(stopTimes.rows.map(row => row.stop_sequence)).to.deep.equal([1, 2, 3]);
+  });
+
+  /**
+   * The last rows of a file arrive after its last chunk, as the inflater and the
+   * parser give up what they were holding, so a merger that only wrote when the
+   * reader paused would lose the end of every feed.
+   */
+  it("writes the calls that arrive after the last pause", async () => {
+    const stopTimes = collect<StopTimeRow>();
+
+    await new StopTimesMerger(stopTimes).write(
+      async (onRow, betweenChunks) => {
+        onRow(stopTime("t1", "s1", 1));
+
+        await betweenChunks();
+
+        onRow(stopTime("t1", "s2", 2));
+      },
+      {t1: "1"},
+      {}
+    );
+
+    expect(stopTimes.rows.map(row => row.stop_id)).to.deep.equal(["s1", "s2"]);
+  });
+
+  it("writes the calls of every chunk, in order", async () => {
+    const stopTimes = collect<StopTimeRow>();
+
+    await new StopTimesMerger(stopTimes).write(
+      reading([
+        [stopTime("t1", "s1", 1), stopTime("t1", "s2", 2)],
+        [stopTime("t2", "s3", 1)],
+        [stopTime("t2", "s4", 2)]
+      ]),
+      {t1: "1", t2: "2"},
+      {}
+    );
+
+    expect(stopTimes.rows.map(row => row.stop_id)).to.deep.equal(["s1", "s2", "s3", "s4"]);
+    expect(stopTimes.rows.map(row => row.trip_id)).to.deep.equal(["1", "1", "2", "2"]);
+  });
+
+  /**
+   * A writer whose buffer is full is waited on, and it is waited on between
+   * chunks rather than between rows.
+   */
+  it("waits for a full writer before reading on", async () => {
+    const stopTimes = collect<StopTimeRow>();
+    let draining = false;
+    let drained = 0;
+
+    stopTimes.write = row => {
+      stopTimes.rows.push({...row});
+
+      return false;
+    };
+
+    stopTimes.drain = async () => {
+      draining = true;
+      drained++;
+
+      await Promise.resolve();
+
+      draining = false;
+    };
+
+    await new StopTimesMerger(stopTimes).write(
+      async (onRow, betweenChunks) => {
+        onRow(stopTime("t1", "s1", 1));
+
+        await betweenChunks();
+
+        expect(draining).to.equal(false);
+
+        onRow(stopTime("t1", "s2", 2));
+      },
+      {t1: "1"},
+      {}
+    );
+
+    expect(drained).to.equal(2);
+    expect(stopTimes.rows.length).to.equal(2);
   });
 
 });

--- a/apps/gtfsmerge/src/gtfs/merger/StopTimesMerger.ts
+++ b/apps/gtfsmerge/src/gtfs/merger/StopTimesMerger.ts
@@ -3,6 +3,24 @@ import {TripIDMap} from "./TripsMerger";
 import {ParentStops} from "./StopsAndTransfersMerger";
 import {close, push} from "./Push";
 
+/**
+ * The stop times of one feed, read on demand.
+ *
+ * A function rather than a list, because the list is the largest thing a merge
+ * holds: the national bus feed's 59 million calls cost 18GB of the 22GB a merge
+ * of it and the rail feed needed, and every one of them is written once and
+ * never read again.
+ *
+ * `onRow` is handed a row the reader reuses, so it is copied or forgotten before
+ * the next one arrives. `betweenChunks` is awaited each time the reader reaches
+ * the end of a chunk of the zip, which is the only place a caller can wait: the
+ * rows themselves arrive from a synchronous parser.
+ */
+export type StopTimeReader = (
+  onRow: (row: StopTimeRow) => void,
+  betweenChunks: () => Promise<void>
+) => Promise<void>;
+
 export class StopTimesMerger {
 
   constructor(
@@ -15,23 +33,45 @@ export class StopTimesMerger {
    * at - which is what decides which stops are published.
    */
   public async write(
-    stopTimes: StopTimeRow[],
+    stopTimes: StopTimeReader,
     tripIdMap: TripIDMap,
     parentStops: ParentStops
   ): Promise<UsedStops> {
     const usedStops: UsedStops = {};
 
-    for (const stopTime of stopTimes) {
-      const tripId = tripIdMap[stopTime.trip_id];
+    // One chunk's worth of calls, held only until the reader next pauses. The
+    // writer is where the backpressure is, and it cannot be waited on from
+    // inside the parser's callback.
+    const batch: StopTimeRow[] = [];
 
-      if (tripId !== undefined) {
-        stopTime.trip_id = tripId;
-        stopTime.stop_id = parentStops[stopTime.stop_id] || stopTime.stop_id;
-        usedStops[stopTime.stop_id] = true;
-
+    const flush = async () => {
+      for (const stopTime of batch) {
         await push(this.stopTimes, stopTime);
       }
-    }
+
+      batch.length = 0;
+    };
+
+    await stopTimes(
+      row => {
+        const tripId = tripIdMap[row.trip_id];
+
+        if (tripId === undefined) {
+          return;
+        }
+
+        const stopId = parentStops[row.stop_id] || row.stop_id;
+
+        usedStops[stopId] = true;
+
+        batch.push({...row, trip_id: tripId, stop_id: stopId});
+      },
+      flush
+    );
+
+    // The reader's last rows arrive after its last chunk, as the inflater and
+    // the parser give up what they were holding.
+    await flush();
 
     return usedStops;
   }

--- a/libs/gtfs-output/package.json
+++ b/libs/gtfs-output/package.json
@@ -31,10 +31,9 @@
   "dependencies": {
     "@gb-transit/gtfs": "workspace:^",
     "@gb-transit/gtfs-schema": "workspace:^",
-    "adm-zip": "0.6.0"
+    "fflate": "^0.8.3"
   },
   "devDependencies": {
-    "@types/adm-zip": "0.5.8",
     "typescript": "7.0.2"
   }
 }

--- a/libs/gtfs-output/src/WriteZip.spec.ts
+++ b/libs/gtfs-output/src/WriteZip.spec.ts
@@ -1,0 +1,142 @@
+import {describe, it, expect, afterEach} from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {unzipSync, strFromU8} from "fflate";
+import {writeZip} from "./WriteZip";
+
+const made: string[] = [];
+
+function scratch(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "writezip"));
+
+  made.push(dir);
+
+  return dir;
+}
+
+function feed(files: Record<string, string>): string {
+  const dir = path.join(scratch(), "work");
+
+  fs.mkdirSync(dir, {recursive: true});
+
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), contents);
+  }
+
+  return dir;
+}
+
+/** A file of the given size that occupies no disk. */
+function sparse(filename: string, size: number): void {
+  const fd = fs.openSync(filename, "w");
+
+  fs.ftruncateSync(fd, size);
+  fs.closeSync(fd);
+}
+
+function read(filename: string): Record<string, string> {
+  const entries = unzipSync(fs.readFileSync(filename));
+  const text: Record<string, string> = {};
+
+  for (const [name, bytes] of Object.entries(entries)) {
+    text[name] = strFromU8(bytes);
+  }
+
+  return text;
+}
+
+afterEach(() => {
+  for (const dir of made.splice(0)) {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+describe("writeZip", () => {
+
+  it("writes every file in the directory", async () => {
+    const dir = feed({"agency.txt": "agency_id\nOP1\n", "stops.txt": "stop_id\n1\n"});
+    const output = path.join(scratch(), "feed.zip");
+
+    await writeZip(dir, output);
+
+    expect(read(output)).to.deep.equal({
+      "agency.txt": "agency_id\nOP1\n",
+      "stops.txt": "stop_id\n1\n"
+    });
+  });
+
+  it("writes the files in a fixed order", async () => {
+    const dir = feed({"stops.txt": "b", "agency.txt": "a", "routes.txt": "c"});
+    const output = path.join(scratch(), "feed.zip");
+
+    await writeZip(dir, output);
+
+    expect(Object.keys(read(output))).to.deep.equal(["agency.txt", "routes.txt", "stops.txt"]);
+  });
+
+  /**
+   * The feed is published as a release asset, and two builds of the same feed
+   * being different files is a difference somebody has to explain. The dates the
+   * entries carry are the only thing in here that is not the feed itself.
+   */
+  it("writes the same bytes for the same feed", async () => {
+    const first = path.join(scratch(), "first.zip");
+    const second = path.join(scratch(), "second.zip");
+
+    await writeZip(feed({"agency.txt": "agency_id\nOP1\n"}), first);
+    await writeZip(feed({"agency.txt": "agency_id\nOP1\n"}), second);
+
+    expect(fs.readFileSync(first)).to.deep.equal(fs.readFileSync(second));
+  });
+
+  it("replaces an archive that is already there", async () => {
+    const output = path.join(scratch(), "feed.zip");
+
+    await writeZip(feed({"agency.txt": "first"}), output);
+    await writeZip(feed({"agency.txt": "second"}), output);
+
+    expect(read(output)["agency.txt"]).to.equal("second");
+  });
+
+  it("survives a file larger than the stream's buffer", async () => {
+    const dir = feed({"stop_times.txt": "x".repeat(96 * 1024 * 1024)});
+    const output = path.join(scratch(), "feed.zip");
+
+    await writeZip(dir, output);
+
+    expect(read(output)["stop_times.txt"].length).to.equal(96 * 1024 * 1024);
+  });
+
+  /**
+   * fflate writes the size into four bytes without checking it fits, so an entry
+   * over 4GB produces an archive that is wrong rather than one that fails.
+   *
+   * The fixture is a sparse file: four gigabytes of size, no blocks, made in the
+   * time it takes to call ftruncate. The guard reads the size and never the
+   * bytes, which is the point of checking the size first.
+   */
+  it("refuses an entry too large for a zip to describe", async () => {
+    const dir = feed({});
+    const output = path.join(scratch(), "feed.zip");
+
+    sparse(path.join(dir, "stop_times.txt"), 0x100000000);
+
+    await expect(writeZip(dir, output)).rejects.toThrow(/stop_times.txt is 4294967296 bytes/);
+  });
+
+  it("leaves the archive that is there when an entry is too large", async () => {
+    const output = path.join(scratch(), "feed.zip");
+
+    await writeZip(feed({"agency.txt": "the feed that works"}), output);
+
+    const dir = feed({"agency.txt": "the feed that does not"});
+
+    sparse(path.join(dir, "stop_times.txt"), 0x100000000);
+
+    await expect(writeZip(dir, output)).rejects.toThrow();
+
+    expect(read(output)["agency.txt"]).to.equal("the feed that works");
+  });
+
+});

--- a/libs/gtfs-output/src/WriteZip.ts
+++ b/libs/gtfs-output/src/WriteZip.ts
@@ -1,6 +1,36 @@
-import AdmZip from "adm-zip";
 import * as fs from "fs";
 import * as path from "node:path";
+import {once} from "node:events";
+import {Zip, ZipDeflate} from "fflate";
+
+/**
+ * The largest entry the archive can describe.
+ *
+ * A zip declares each entry's size in four bytes, and fflate writes those four
+ * bytes without checking what it was given: a larger file has its size written
+ * modulo 2^32 and the archive is silently wrong. The alternative is zip64, which
+ * fflate does not write.
+ *
+ * A merged GB feed's stop_times.txt is around 3GB, so this is a limit the feed
+ * is approaching rather than one it will never reach. It is checked, and the
+ * build fails, because a zip that says it holds 700MB of stop times and holds
+ * 5GB is worse than no zip at all.
+ */
+const MAX_ENTRY_SIZE = 0xFFFFFFFF;
+
+/**
+ * The timestamp every entry is written with.
+ *
+ * A zip entry carries the modification time of the file it came from, and the
+ * files a feed is built from are written afresh by every build - so the same
+ * feed produced two zips that differed, in the sixteen bytes holding the dates.
+ * Fixed, they are the same archive. The date itself is arbitrary; it only has to
+ * be inside the range a zip can hold, which begins in 1980.
+ */
+const MTIME = Date.UTC(1980, 0, 2);
+
+/** How much may sit in the output stream's buffer before the read pauses. */
+const HIGH_WATER_MARK = 64 * 1024 * 1024;
 
 /**
  * A directory of files as a GTFS zip.
@@ -10,17 +40,85 @@ import * as path from "node:path";
  * and awaited, so this resolves when the file exists rather than when a timer is
  * due to start writing it, and a failure fails the build instead of being thrown
  * into an empty stack.
+ *
+ * Streamed a file at a time rather than assembled in memory. adm-zip, which this
+ * used, held the whole archive and refused any entry over 2GB - which a feed
+ * with bus stop times in it exceeds.
  */
 export async function writeZip(directory: string, filename: string): Promise<void> {
+  const files = fs.readdirSync(directory).sort();
+
+  // Before anything is written, so an entry that cannot be described leaves the
+  // previous archive where it is rather than half replacing it.
+  for (const file of files) {
+    const {size} = fs.statSync(path.join(directory, file));
+
+    if (size > MAX_ENTRY_SIZE) {
+      throw new Error(
+        `${file} is ${size} bytes, and a zip entry may be at most ${MAX_ENTRY_SIZE}. `
+        + "Writing it would produce an archive that decompresses to the wrong thing."
+      );
+    }
+  }
+
   if (fs.existsSync(filename)) {
     fs.unlinkSync(filename);
   }
 
-  const zip = new AdmZip();
+  const out = fs.createWriteStream(filename);
+  const zip = new Zip();
 
-  for (const file of fs.readdirSync(directory).sort()) {
-    zip.addLocalFile(path.join(directory, file));
+  const written = new Promise<void>((resolve, reject) => {
+    zip.ondata = (err, chunk, final) => {
+      if (err) {
+        reject(err);
+
+        return;
+      }
+
+      out.write(chunk);
+
+      if (final) {
+        out.end();
+      }
+    };
+
+    out.on("error", reject);
+    out.on("finish", resolve);
+  });
+
+  try {
+    for (const file of files) {
+      const entry = new ZipDeflate(file);
+
+      // Before it is added: adding an entry writes its header, and the header is
+      // where the date goes.
+      entry.mtime = MTIME;
+
+      zip.add(entry);
+
+      for await (const chunk of fs.createReadStream(path.join(directory, file))) {
+        entry.push(chunk, false);
+
+        // fflate hands each compressed chunk straight to `ondata`, which cannot
+        // wait, so the backpressure has to be applied to the file being read
+        // instead of to the archive being written.
+        if (out.writableLength > HIGH_WATER_MARK) {
+          await once(out, "drain");
+        }
+      }
+
+      entry.push(new Uint8Array(0), true);
+    }
+
+    zip.end();
+
+    await written;
   }
+  catch (err) {
+    out.destroy();
+    fs.rmSync(filename, {force: true});
 
-  await zip.writeZipPromise(filename);
+    throw err;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,8 +863,7 @@ __metadata:
   dependencies:
     "@gb-transit/gtfs": "workspace:^"
     "@gb-transit/gtfs-schema": "workspace:^"
-    "@types/adm-zip": "npm:0.5.8"
-    adm-zip: "npm:0.6.0"
+    fflate: "npm:^0.8.3"
     typescript: "npm:7.0.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Merging the published rail feed with the Bus Open Data Service's national feed fails twice over
today. This fixes both, and neither fix is specific to buses — they are the two places the tools
assume a feed is rail sized.

The measurements below are that merge: `gtfs.zip` from the latest release, and the national BODS
GTFS capped to the same three months, on `--no-extra-transfers`.

## It runs out of memory

`stop_times.txt` is almost all of a feed, and the merge held every input feed whole. Measured, held
the way the merge held them:

| held | rows | heap |
|---|---|---|
| everything except stop times | 1,854,991 | 0.7GB |
| stop times | 59,129,908 | 18.0GB |

96% of the memory for one file. The merge peaked at 22.1GB, and at the 8GB `bin/gtfsmerge.sh`
allows it died after 43 seconds:

```
Loading rail.zip / Processing rail.zip / Loading bus.zip
FATAL ERROR: Ineffective mark-compacts near heap limit - JavaScript heap out of memory
```

The order the merge already worked in is why they need not be held. Nothing can be done with a call
until its trip has been numbered — and the trips are numbered from the routes and calendars —
and nothing needs the call afterwards. So `readMergeInput` reads everything but the stop times, and
`stopTimesOf` reads the file a second time for those alone. Each call is remapped, written and let
go.

The second read is what this costs, and it is a read of a file rather than a copy of it in memory.

## It cannot write the answer

Having built the feed, it could not put it anywhere:

```
Writing merged.zip
File size (2955798571) is greater than 2 GiB
```

`writeZip` used adm-zip, which assembles the archive in memory and refuses an entry over 2GB.
It now streams through fflate, which the reader and four other packages here already use.

## Where that leaves it

| | before | after |
|---|---|---|
| peak memory | 22.1GB | 3.3GB |
| heap needed | more than 8GB | inside the shipped 8GB |
| wall clock | 2:54, then failed | 3:26, complete |
| output | none | 669MB zip, `unzip -t` clean |

All eight files of the merged feed are byte for byte the ones the old code produced before it failed
to write them, checked against a run that got as far as a directory.

## Two limits that remain, now explicit

- fflate writes an entry's size into four bytes and does not check that it fits, so a file over 4GB
  would produce an archive that decompresses to the wrong thing, silently. The sizes are checked
  before anything is written and a file too large fails the build by name. The merged
  `stop_times.txt` is 2.96GB, so this is a limit the feed is approaching rather than one it will
  never reach; zip64, which fflate does not write, is what lifts it.
- Entries now carry a fixed date rather than the mtime of the file they came from, so two builds of
  the same feed produce the same bytes. They did not before, though the comment said they should.

## Not in here

Generated transfers. `StopsAndTransfersMerger.addNearbyStops` compares each stop against every stop
seen so far: 321,570 stops is 51.7 billion comparisons, which extrapolates to about four hours and
25 million `transfers.txt` rows. That wants a spatial index and a shorter default distance for bus
stops, and it is a separate change.

The reader also holds the compressed bytes of any entry it declines, which costs the first pass
about 1GB on a national feed. Left alone deliberately: the fix is either to inflate and discard,
which slows every caller of `gtfs-loader` that declines a file, or a seek-based reader for local
files. Neither belongs in this change.