### PR TITLE
Make a line something you can look at

### DIFF
--- a/apps/website/src/explorer/route.ts
+++ b/apps/website/src/explorer/route.ts
@@ -14,6 +14,7 @@ export type Route =
   | {view: "stop", id: string}
   | {view: "trip", id: string}
   | {view: "route", id: string}
+  | {view: "shape", id: string}
   | {view: "service", id: string}
   | {view: "board", id: string, date: number}
   | {view: "checks", id?: string}
@@ -63,6 +64,7 @@ export function parse(hash: string): Route {
     case "trip":
     case "route":
     case "service":
+    case "shape":
       return parts[1] === undefined
         ? {view: "overview"}
         : {view: parts[0], id: parts[1]} as Route;
@@ -127,6 +129,7 @@ export function format(route: Route): string {
     case "trip":
     case "route":
     case "service":
+    case "shape":
       return `#/${route.view}/${encodeURIComponent(route.id)}`;
 
     case "board":

--- a/apps/website/src/explorer/test/explorer.spec.ts
+++ b/apps/website/src/explorer/test/explorer.spec.ts
@@ -5,7 +5,8 @@ import {Links} from "../model/Links.js";
 import {CHECKS, checkOf} from "../checks/checks.js";
 import {runCheck} from "../checks/Check.js";
 import type {CheckContext, Finding} from "../checks/Check.js";
-import {boardAt, routeDetail, serviceDetail, stopDetail, tripDetail} from "../worker/Details.js";
+import {boardAt, routeDetail, serviceDetail, shapeViewDetail, stopDetail, tripDetail}
+  from "../worker/Details.js";
 import {tableOf} from "../query/Table.js";
 import {run} from "../query/Filter.js";
 import {brokenFeed, goldenFeed} from "./golden.js";
@@ -299,6 +300,63 @@ describe("the entity views", () => {
       .map(id => loaded.feed.files.get("trips.txt")!.index("shape_id").get(id)!.length);
 
     expect(Math.max(...counts)).to.be.greaterThan(1);
+  });
+
+  /**
+   * A shape is shared, so "what else runs over this line" is a question only the shape can answer -
+   * a trip knows its own line and nothing about its neighbours.
+   */
+  it("gives a shape the trips that run over it", () => {
+    const shapeId = tripDetail(loaded, "C00049_20260517_20261206").shape!.id;
+    const detail = shapeViewDetail(loaded, shapeId);
+
+    expect(detail.points.length).to.be.greaterThan(1);
+    expect(detail.totalTrips).to.be.greaterThan(0);
+    expect(detail.trips.map(trip => trip.id)).to.contain("C00049_20260517_20261206");
+  });
+
+  it("measures a line in kilometres along it, not between its ends", () => {
+    const shapeId = tripDetail(loaded, "C04566_20260518_20261207").shape!.id;
+    const detail = shapeViewDetail(loaded, shapeId);
+    const [first] = detail.points;
+    const last = detail.points[detail.points.length - 1];
+    const straight = Math.hypot(
+      (last[0] - first[0]) * 111.32,
+      (last[1] - first[1]) * 111.32 * Math.cos(first[0] * Math.PI / 180)
+    );
+
+    // A line that bends is longer than the crow's flight between its ends
+    expect(detail.length).to.be.greaterThan(straight);
+  });
+
+  it("says a shape it does not have is not there, rather than drawing nothing", () => {
+    const detail = shapeViewDetail(loaded, "NO_SUCH_SHAPE");
+
+    expect(detail.points).to.deep.equal([]);
+    expect(detail.totalTrips).to.equal(0);
+  });
+
+  /**
+   * A route is not one line. A stopping pattern that diverts and a portion that splits are the same
+   * route over different ground, and the route view draws all of it.
+   */
+  it("gives a route every distinct line its trips run over", () => {
+    const routeId = tripDetail(loaded, "C00049_20260517_20261206").route!.route_id as string;
+    const detail = routeDetail(loaded, routeId);
+
+    expect(detail.lines).to.not.equal(undefined);
+    expect(detail.lines!.shapes).to.be.greaterThan(0);
+    expect(detail.lines!.lines.length).to.equal(detail.lines!.drawn);
+    expect(detail.lines!.lines.every(line => line.length > 1)).to.equal(true);
+  });
+
+  it("draws no more of a route's lines than a map can tell apart", () => {
+    for (const routeId of new Set(loaded.feed.files.get("trips.txt")!.index("route_id").keys())) {
+      const drawn = routeDetail(loaded, routeId).lines;
+
+      expect(drawn === undefined || drawn.drawn <= 12, routeId).to.equal(true);
+      expect(drawn === undefined || drawn.drawn <= drawn.shapes, routeId).to.equal(true);
+    }
   });
 
   it("expands a trip's calendar to real dates with the exclusions marked", () => {

--- a/apps/website/src/explorer/ui/Tiles.spec.ts
+++ b/apps/website/src/explorer/ui/Tiles.spec.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from "vitest";
-import {unit, zoomFor} from "./Tiles.js";
+import {parseLines, unit, zoomFor} from "./Tiles.js";
 
 /**
  * The arithmetic behind the maps.
@@ -73,6 +73,40 @@ describe("zoomFor", () => {
     const zoom = zoomFor(0, 0.01, BOX);
 
     expect(0.01 * 256 * 2 ** zoom).to.be.at.most(BOX.height);
+  });
+
+});
+
+describe("parseLines", () => {
+
+  it("reads a list of lines", () => {
+    expect(parseLines("[[[1,2],[3,4]],[[5,6],[7,8]]]"))
+      .to.deep.equal([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
+  });
+
+  it("reads an empty list", () => {
+    expect(parseLines("[]")).to.deep.equal([]);
+  });
+
+  /**
+   * The bug this exists for. One line passed the way a single line used to be is a flat list of
+   * pairs, which by shape alone is a list of two-point lines - so it drew a scatter of stubs and
+   * said nothing. Nothing but a browser caught it.
+   */
+  it("refuses a flat list of pairs, which is one line in the wrong wrapper", () => {
+    expect(() => parseLines("[[1,2],[3,4]]")).to.throw(/wrap it in an array/);
+  });
+
+  it("refuses a point that is not a pair", () => {
+    expect(() => parseLines("[[[1,2,3]]]")).to.throw(/latitude, longitude/);
+  });
+
+  it("refuses a coordinate that is not a number", () => {
+    expect(() => parseLines("[[[1,\"two\"]]]")).to.throw(/latitude, longitude/);
+  });
+
+  it("refuses something that is not a list at all", () => {
+    expect(() => parseLines("{}")).to.throw(/array of lines/);
   });
 
 });

--- a/apps/website/src/explorer/ui/Tiles.ts
+++ b/apps/website/src/explorer/ui/Tiles.ts
@@ -69,13 +69,61 @@ export function showMap(container: HTMLElement, lat: number, lon: number): void 
  * one of those.
  */
 export function showLine(container: HTMLElement, points: readonly LinePoint[]): void {
-  if (points.length < 2) {
+  showLines(container, [points]);
+}
+
+/**
+ * Read the lines a view carried in its markup.
+ *
+ * A list of lines, each a list of latitude and longitude pairs. Anything else throws rather than
+ * drawing what it can: a flat list of pairs - one line, passed the way a single line used to be -
+ * is indistinguishable from a list of two-point lines by shape alone, and quietly draws a scatter
+ * of two-point stubs. That was a real bug and nothing but the browser caught it.
+ */
+export function parseLines(json: string): LinePoint[][] {
+  const parsed: unknown = JSON.parse(json);
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("A map's lines have to be an array of lines.");
+  }
+
+  return parsed.map(line => {
+    if (!Array.isArray(line)) {
+      throw new Error("Each line has to be an array of points.");
+    }
+
+    return line.map(point => {
+      if (!Array.isArray(point) || point.length !== 2
+        || !Number.isFinite(point[0]) || !Number.isFinite(point[1])) {
+        throw new Error(
+          "Each point has to be a [latitude, longitude] pair. A flat list of pairs is one line "
+          + "passed where a list of lines belongs - wrap it in an array."
+        );
+      }
+
+      return [point[0], point[1]] as LinePoint;
+    });
+  });
+}
+
+/**
+ * Draw several lines at once, zoomed to hold all of them.
+ *
+ * What a route view wants: every distinct line its trips run over, on one map. The ends are only
+ * marked when there is one line - a dozen start and end dots over a route's worth of overlapping
+ * lines is confetti, and none of them says which line it belongs to.
+ */
+export function showLines(container: HTMLElement, lines: readonly (readonly LinePoint[])[]): void {
+  const drawable = lines.filter(points => points.length > 1);
+
+  if (drawable.length === 0) {
     return;
   }
 
   const width = Math.max(container.clientWidth, 160);
   const box = {width: width - PADDING * 2, height: LINE_HEIGHT - PADDING * 2};
-  const corners = points.map(([lat, lon]) => unit(lat, lon));
+  const projected = drawable.map(points => points.map(([lat, lon]) => unit(lat, lon)));
+  const corners = projected.flat();
   const min = {x: Math.min(...corners.map(p => p.x)), y: Math.min(...corners.map(p => p.y))};
   const max = {x: Math.max(...corners.map(p => p.x)), y: Math.max(...corners.map(p => p.y))};
   const zoom = zoomFor(max.x - min.x, max.y - min.y, box);
@@ -91,8 +139,10 @@ export function showLine(container: HTMLElement, points: readonly LinePoint[]): 
   map.className = "map";
   map.style.height = `${LINE_HEIGHT}px`;
   map.setAttribute("role", "img");
-  map.setAttribute("aria-label",
-    `A map of the line this trip runs over, from OpenStreetMap. It is described below.`);
+  map.setAttribute("aria-label", drawable.length === 1
+    ? "A map of the line this runs over, from OpenStreetMap. It is described below."
+    : `A map of the ${drawable.length} lines this runs over, from OpenStreetMap. They are `
+      + `described below.`);
 
   tileGrid(map, left, top, width, LINE_HEIGHT, zoom);
 
@@ -104,22 +154,29 @@ export function showLine(container: HTMLElement, points: readonly LinePoint[]): 
   svg.setAttribute("height", String(LINE_HEIGHT));
   svg.setAttribute("aria-hidden", "true");
 
-  const plotted = corners.map(p => [p.x * scale - left, p.y * scale - top] as const);
-  const line = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
+  const plotted = projected.map(points =>
+    points.map(p => [p.x * scale - left, p.y * scale - top] as const));
 
-  line.setAttribute("points", plotted.map(([x, y]) => `${round(x)},${round(y)}`).join(" "));
-  svg.appendChild(line);
+  for (const points of plotted) {
+    const line = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
 
-  // The ends, so the direction of travel is readable off the picture. Drawn after the line so they
-  // sit over it rather than under.
-  for (const [index, name] of [[0, "start"], [plotted.length - 1, "end"]] as const) {
-    const dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    line.setAttribute("class", plotted.length === 1 ? "map__one" : "map__many");
+    line.setAttribute("points", points.map(([x, y]) => `${round(x)},${round(y)}`).join(" "));
+    svg.appendChild(line);
+  }
 
-    dot.setAttribute("class", `map__end map__end--${name}`);
-    dot.setAttribute("cx", round(plotted[index][0]));
-    dot.setAttribute("cy", round(plotted[index][1]));
-    dot.setAttribute("r", "5");
-    svg.appendChild(dot);
+  // The ends, so the direction of travel is readable off the picture. Drawn after the lines so they
+  // sit over them rather than under, and only for a single line - see above.
+  if (plotted.length === 1) {
+    for (const [index, name] of [[0, "start"], [plotted[0].length - 1, "end"]] as const) {
+      const dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+
+      dot.setAttribute("class", `map__end map__end--${name}`);
+      dot.setAttribute("cx", round(plotted[0][index][0]));
+      dot.setAttribute("cy", round(plotted[0][index][1]));
+      dot.setAttribute("r", "5");
+      svg.appendChild(dot);
+    }
   }
 
   map.appendChild(svg);

--- a/apps/website/src/explorer/ui/boot.ts
+++ b/apps/website/src/explorer/ui/boot.ts
@@ -6,14 +6,13 @@ import {format, parse} from "../route.js";
 import type {Route} from "../route.js";
 import {bytes, number} from "../format.js";
 import type {
-  BoardDetail, RouteDetail, ServiceDetail, StopDetail, TripDetail
+  BoardDetail, RouteDetail, ServiceDetail, ShapeViewDetail, StopDetail, TripDetail
 } from "../worker/Detail.js";
 import {Explorer, startWorker, workersSupported} from "../worker/client.js";
 import type {Opened} from "../worker/client.js";
 import type {OpenSource} from "../worker/protocol.js";
 import {element, escape, focusHeading} from "./dom.js";
-import {showLine, showMap} from "./Tiles.js";
-import type {LinePoint} from "./Tiles.js";
+import {parseLines, showLines, showMap} from "./Tiles.js";
 import {PAGE_SIZE, fileTable} from "./views/FileTable.js";
 import {overview} from "./views/Overview.js";
 import {stopView} from "./views/Stop.js";
@@ -21,6 +20,7 @@ import {tripView} from "./views/Trip.js";
 import {boardView} from "./views/Board.js";
 import {checksView} from "./views/Checks.js";
 import {routeView, serviceView} from "./views/Simple.js";
+import {shapeView} from "./views/Shape.js";
 import {validationView} from "./views/Validation.js";
 import {provenanceView} from "./views/Provenance.js";
 import {groups, readReport} from "../validation.js";
@@ -334,6 +334,12 @@ async function html_(route: Route, id: number): Promise<string> {
       return routeView(value);
     }
 
+    case "shape": {
+      const {value} = await ask.ask<ShapeViewDetail>({type: "shape", slot: "a", shapeId: route.id});
+
+      return shapeView(value);
+    }
+
     case "service": {
       const {value} = await ask.ask<ServiceDetail>({type: "service", slot: "a", serviceId: route.id});
 
@@ -556,9 +562,7 @@ function drawMap(view: HTMLElement): void {
  */
 function drawLine(panel: HTMLElement): void {
   try {
-    const points = JSON.parse(panel.dataset.line ?? "[]") as LinePoint[];
-
-    showLine(panel, points);
+    showLines(panel, parseLines(panel.dataset.line ?? "[]"));
   }
   catch {
     panel.remove();

--- a/apps/website/src/explorer/ui/views/FileTable.ts
+++ b/apps/website/src/explorer/ui/views/FileTable.ts
@@ -22,7 +22,7 @@ export const PAGE_SIZE = 200;
 export function fileTable(page: Page, route: Extract<Route, {view: "file"}>): string {
   const columns = [...page.header];
   const linkable = new Set(["stop_id", "parent_station", "from_stop_id", "to_stop_id",
-    "trip_id", "from_trip_id", "to_trip_id", "route_id", "service_id"]);
+    "trip_id", "from_trip_id", "to_trip_id", "route_id", "service_id", "shape_id"]);
 
   const head = columns.map(column => {
     const descending = route.sort === column && !route.descending;

--- a/apps/website/src/explorer/ui/views/Shape.ts
+++ b/apps/website/src/explorer/ui/views/Shape.ts
@@ -1,0 +1,75 @@
+import type {ShapeViewDetail} from "../../worker/Detail.js";
+import {format} from "../../route.js";
+import {number} from "../../format.js";
+import {escape} from "../dom.js";
+
+/**
+ * One line, and what runs over it.
+ *
+ * A shape gets a view of its own because it is shared. A trip has one line, but a line has many
+ * trips - the fast and the stopper over the same ground carry the same id - and "what else runs
+ * here" is a question only this end can answer.
+ */
+export function shapeView(detail: ShapeViewDetail): string {
+  if (detail.points.length === 0) {
+    return `
+      <h2 class="h h1" tabindex="-1" data-heading>${escape(detail.id)}</h2>
+      <p class="empty">shapes.txt has no such shape.${detail.totalTrips === 0 ? "" :
+        ` ${number(detail.totalTrips)} trip${detail.totalTrips === 1 ? "" : "s"} name it, so their
+        shape_id is dangling — the integrity checks report this.`}</p>`;
+  }
+
+  return `
+    <h2 class="h h1" tabindex="-1" data-heading>${escape(detail.id)}</h2>
+    <p class="lede">
+      A line through ${number(detail.points.length)} station${detail.points.length === 1 ? "" : "s"}
+      &middot; ${detail.length < 10 ? detail.length.toFixed(1) : number(Math.round(detail.length))} km
+      &middot; ${number(detail.totalTrips)} trip${detail.totalTrips === 1 ? "" : "s"}
+    </p>
+
+    ${detail.points.length < 2
+      ? `<p class="warn">One point is not a line, so there is nothing to draw. The integrity checks
+         report this.</p>`
+      : `<div class="plot__map" data-line="${escape(JSON.stringify([detail.points]))}"></div>
+         <p class="note plot__there">
+           The line runs through every station a train touches, calling or passing. Between two of
+           them it is straight, because the feed has no coordinate for the junctions in between.
+         </p>`}
+
+    <p class="note">
+      <a href="${format({view: "file", file: "shapes.txt", page: 0,
+        filters: {shape_id: detail.id}})}">The rows&nearr;</a>
+    </p>
+
+    ${trips(detail)}`;
+}
+
+/**
+ * The trips over this line.
+ *
+ * The list is the point of the view: a line with three hundred trips on it is a line the timetable
+ * leans on, and that is not visible from any one of them.
+ */
+function trips(detail: ShapeViewDetail): string {
+  if (detail.totalTrips === 0) {
+    return `<h3 class="h h2">What runs over it</h3>
+      <p class="empty">No trip names this shape, so nothing is drawn along it. The integrity checks
+      report a line nothing runs over.</p>`;
+  }
+
+  const items = detail.trips.map(trip => `<li>
+    <a href="${format({view: "trip", id: trip.id})}">${escape(trip.id)}</a>
+    ${trip.headsign === undefined ? "" : `to ${escape(trip.headsign)}`}
+    ${trip.routeId === undefined ? "" : `<a class="note" href="${format({view: "route",
+      id: trip.routeId})}">${escape(trip.routeId)}</a>`}
+  </li>`).join("");
+
+  return `
+    <h3 class="h h2">What runs over it</h3>
+    ${detail.totalTrips > detail.trips.length
+      ? `<p class="note">${number(detail.trips.length)} of ${number(detail.totalTrips)} shown.
+         <a href="${format({view: "file", file: "trips.txt", page: 0,
+           filters: {shape_id: detail.id}})}">All of them&nearr;</a></p>`
+      : ""}
+    <ul class="links">${items}</ul>`;
+}

--- a/apps/website/src/explorer/ui/views/Simple.ts
+++ b/apps/website/src/explorer/ui/views/Simple.ts
@@ -1,4 +1,4 @@
-import type {RouteDetail, ServiceDetail} from "../../worker/Detail.js";
+import type {RouteDetail, RouteLines, ServiceDetail} from "../../worker/Detail.js";
 import type {ServiceDate} from "../../model/Calendar.js";
 import {format} from "../../route.js";
 import {formatDate, number, routeTypeOf, weekdayOf} from "../../format.js";
@@ -33,6 +33,7 @@ export function routeView(detail: RouteDetail): string {
       ${Object.entries(row).map(([column, value]) =>
         `<div class="field"><dt>${escape(column)}</dt><dd>${cell(value)}</dd></div>`).join("")}
     </dl>
+    ${lines(detail)}
     <h3 class="h h2">Trips on this route</h3>
     ${list(detail.trips.map(trip => `
       <li><a href="${format({view: "trip", id: trip.id})}">${escape(trip.shortName ?? trip.id)}</a>
@@ -40,6 +41,42 @@ export function routeView(detail: RouteDetail): string {
         ${trip.serviceId === undefined ? "" : `<a class="note" href="${format({view: "service",
           id: trip.serviceId})}">service ${escape(trip.serviceId)}</a>`}</li>`),
       detail.totalTrips, detail.trips.length, "route_id", detail.id)}`;
+}
+
+/**
+ * Where the route goes, as opposed to which trips are on it.
+ *
+ * Every distinct line its trips run over, drawn together. A route is not one line: a stopping
+ * pattern that diverts, a portion that splits and a weekend variation are all the same route and
+ * different ground, and the picture is the only place that shows.
+ */
+function lines(detail: RouteDetail): string {
+  const drawn = detail.lines;
+
+  if (drawn === undefined) {
+    return "";
+  }
+
+  return `
+    <h3 class="h h2">Where it goes</h3>
+    <div class="plot__map" data-line="${escape(JSON.stringify(drawn.lines))}"></div>
+    <p class="note plot__there">
+      ${describe(drawn)}
+      Each line runs through every station a train touches, calling or passing; between two of them
+      it is straight, because the feed has no coordinate for the junctions in between.
+    </p>`;
+}
+
+function describe(drawn: RouteLines): string {
+  if (drawn.shapes === 1) {
+    return "Every trip on this route runs over one line.";
+  }
+
+  return `${number(drawn.shapes)} distinct lines carry this route`
+    + (drawn.drawn < drawn.shapes
+      ? `, of which the ${number(drawn.drawn)} busiest are drawn.`
+      : ", all drawn.")
+    + " Where they overlap they are running over the same ground.";
 }
 
 export function serviceView(detail: ServiceDetail): string {

--- a/apps/website/src/explorer/ui/views/Trip.ts
+++ b/apps/website/src/explorer/ui/views/Trip.ts
@@ -73,7 +73,7 @@ function line(detail: TripDetail): string {
 
   return `
     <h3 class="h h2">The line it runs over</h3>
-    <div class="plot__map" data-line="${escape(JSON.stringify(shape.points))}"></div>
+    <div class="plot__map" data-line="${escape(JSON.stringify([shape.points]))}"></div>
     ${described(shape)}
     <p class="note">
       <a href="${format({view: "file", file: "shapes.txt", page: 0,

--- a/apps/website/src/explorer/worker/Detail.ts
+++ b/apps/website/src/explorer/worker/Detail.ts
@@ -95,12 +95,42 @@ export interface LinkDetail {
   readonly row: number;
 }
 
+/**
+ * One line, and the trips that run over it.
+ *
+ * A shape is a first class thing to look at rather than only a column on a trip: it is shared, so
+ * "what else runs over this" is a question it can answer and a trip cannot.
+ */
+export interface ShapeViewDetail {
+  readonly id: string;
+  readonly points: readonly (readonly [number, number])[];
+  readonly length: number;
+  /** Capped like every other list here; `totalTrips` is the real count. */
+  readonly trips: readonly {id: string, headsign?: string, routeId?: string}[];
+  readonly totalTrips: number;
+}
+
+/**
+ * The lines a route's trips run over, for drawing all of them at once.
+ *
+ * Points rather than shapes, because a route view wants a picture of where the route goes and not a
+ * list of ids. A route with more distinct lines than can be told apart on one map draws the
+ * busiest and says how many it left out.
+ */
+export interface RouteLines {
+  readonly lines: readonly (readonly (readonly [number, number])[])[];
+  readonly shapes: number;
+  readonly drawn: number;
+}
+
 export interface RouteDetail {
   readonly id: string;
   readonly row?: Row;
   readonly agency?: Row;
   readonly trips: readonly {id: string, headsign?: string, shortName?: string, serviceId?: string}[];
   readonly totalTrips: number;
+  /** Where the route's trips go, drawn. Absent where the feed has no shapes. */
+  readonly lines?: RouteLines;
 }
 
 export interface ServiceDetail {

--- a/apps/website/src/explorer/worker/Details.ts
+++ b/apps/website/src/explorer/worker/Details.ts
@@ -10,8 +10,8 @@ import type {Links} from "../model/Links.js";
 import type {Provenance} from "../provenance.js";
 import {formatClock, formatTime, metresBetween} from "../format.js";
 import type {
-  BoardDetail, CallDetail, Departure, LinkDetail, RouteDetail, ServiceDetail, ShapeDetail, StopDetail,
-  TripDetail
+  BoardDetail, CallDetail, Departure, LinkDetail, RouteDetail, RouteLines, ServiceDetail, ShapeDetail,
+  ShapeViewDetail, StopDetail, TripDetail
 } from "./Detail.js";
 
 /**
@@ -24,6 +24,14 @@ import type {
  * anybody reads; the count is reported and the file table is where the rest of them live.
  */
 const LIST_LIMIT = 200;
+
+/**
+ * How many of a route's lines are drawn at once.
+ *
+ * A dozen is already a thicket. Past that the map stops saying "the route goes here" and starts
+ * saying nothing, so the busiest are drawn and the count of the rest is written underneath.
+ */
+const ROUTE_LINE_LIMIT = 12;
 
 export interface Loaded {
   feed: FeedIndex;
@@ -120,27 +128,15 @@ export function tripDetail(loaded: Loaded, tripId: string): TripDetail {
  * in a feed somebody else built should cost that point and not the picture.
  */
 function shapeDetail(feed: FeedIndex, shapeId: string | undefined): ShapeDetail | undefined {
-  const shapes = feed.files.get("shapes.txt");
-
-  if (shapeId === undefined || shapeId === "" || shapes === undefined) {
+  if (shapeId === undefined || shapeId === "" || feed.files.get("shapes.txt") === undefined) {
     return undefined;
   }
 
-  const rows = shapes.index("shape_id").get(shapeId);
+  const points = pointsOf(feed, shapeId);
 
-  if (rows === undefined || rows.length === 0) {
+  if (points === undefined) {
     return undefined;
   }
-
-  const points = rows
-    .map(row => ({
-      sequence: Number(shapes.value("shape_pt_sequence", row)),
-      lat: Number(shapes.value("shape_pt_lat", row)),
-      lon: Number(shapes.value("shape_pt_lon", row))
-    }))
-    .filter(point => Number.isFinite(point.lat) && Number.isFinite(point.lon))
-    .sort((a, b) => a.sequence - b.sequence)
-    .map(point => [point.lat, point.lon] as const);
 
   const trips = feed.files.get("trips.txt")?.index("shape_id").get(shapeId)?.length ?? 0;
 
@@ -151,6 +147,94 @@ function shapeDetail(feed: FeedIndex, shapeId: string | undefined): ShapeDetail 
     length: lengthOf(points),
     undrawable: points.length < 2 ? true : undefined
   };
+}
+
+/**
+ * One line's points, in sequence order, or nothing where the feed does not have that shape.
+ *
+ * Sorted rather than taken in file order: GTFS does not require shapes.txt to be sorted, and a
+ * caller drawing an unsorted one gets a scribble. A point whose coordinate does not parse is
+ * dropped rather than the shape abandoned - one bad row in a feed somebody else built should cost
+ * that point and not the picture.
+ */
+function pointsOf(feed: FeedIndex, shapeId: string): (readonly [number, number])[] | undefined {
+  const shapes = feed.files.get("shapes.txt");
+  const rows = shapes?.index("shape_id").get(shapeId);
+
+  if (shapes === undefined || rows === undefined || rows.length === 0) {
+    return undefined;
+  }
+
+  return rows
+    .map(row => ({
+      sequence: Number(shapes.value("shape_pt_sequence", row)),
+      lat: Number(shapes.value("shape_pt_lat", row)),
+      lon: Number(shapes.value("shape_pt_lon", row))
+    }))
+    .filter(point => Number.isFinite(point.lat) && Number.isFinite(point.lon))
+    .sort((a, b) => a.sequence - b.sequence)
+    .map(point => [point.lat, point.lon] as const);
+}
+
+/**
+ * One line, with the trips that run over it.
+ */
+export function shapeViewDetail(loaded: Loaded, shapeId: string): ShapeViewDetail {
+  const {feed} = loaded;
+  const points = pointsOf(feed, shapeId) ?? [];
+  const trips = feed.files.get("trips.txt");
+  const rows = trips?.index("shape_id").get(shapeId) ?? [];
+
+  return {
+    id: shapeId,
+    points,
+    length: lengthOf(points),
+    trips: rows.slice(0, LIST_LIMIT).map(row => ({
+      id: trips!.value("trip_id", row) as string,
+      headsign: trips!.value("trip_headsign", row),
+      routeId: trips!.value("route_id", row)
+    })),
+    totalTrips: rows.length
+  };
+}
+
+/**
+ * Every distinct line a route's trips run over.
+ *
+ * Ordered by how many trips run over each, so a route with more lines than a map can tell apart
+ * draws the ones that carry the service and says how many it left out. That order also makes the
+ * picture stable between builds, which taking them in trip order would not.
+ */
+function routeLines(feed: FeedIndex, tripRows: readonly number[]): RouteLines | undefined {
+  const trips = feed.files.get("trips.txt");
+
+  if (trips === undefined || feed.files.get("shapes.txt") === undefined) {
+    return undefined;
+  }
+
+  const counts = new Map<string, number>();
+
+  for (const row of tripRows) {
+    const shapeId = trips.value("shape_id", row);
+
+    if (shapeId !== undefined && shapeId !== "") {
+      counts.set(shapeId, (counts.get(shapeId) ?? 0) + 1);
+    }
+  }
+
+  if (counts.size === 0) {
+    return undefined;
+  }
+
+  const busiest = [...counts]
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
+    .slice(0, ROUTE_LINE_LIMIT);
+  const lines = busiest
+    .map(([shapeId]) => pointsOf(feed, shapeId))
+    .filter((points): points is (readonly [number, number])[] =>
+      points !== undefined && points.length > 1);
+
+  return lines.length === 0 ? undefined : {lines, shapes: counts.size, drawn: lines.length};
 }
 
 /**
@@ -197,7 +281,8 @@ export function routeDetail(loaded: Loaded, routeId: string): RouteDetail {
       shortName: trips!.value("trip_short_name", trip),
       serviceId: trips!.value("service_id", trip)
     })),
-    totalTrips: rows.length
+    totalTrips: rows.length,
+    lines: routeLines(feed, rows)
   };
 }
 

--- a/apps/website/src/explorer/worker/explorer.worker.ts
+++ b/apps/website/src/explorer/worker/explorer.worker.ts
@@ -7,7 +7,7 @@ import {tableOf} from "../query/Table.js";
 import {toCSV, toJSON} from "../query/Export.js";
 import {CHECKS} from "../checks/checks.js";
 import {runCheck} from "../checks/Check.js";
-import {boardAt, routeDetail, serviceDetail, stopDetail, tripDetail} from "./Details.js";
+import {boardAt, routeDetail, serviceDetail, shapeViewDetail, stopDetail, tripDetail} from "./Details.js";
 import {Provenance, readProvenance} from "../provenance.js";
 import type {Request, Response, Slot} from "./protocol.js";
 
@@ -76,6 +76,9 @@ async function handle(request: Request): Promise<void> {
 
     case "route":
       return result(request.id, routeDetail(loaded, request.routeId));
+
+    case "shape":
+      return result(request.id, shapeViewDetail(loaded, request.shapeId));
 
     case "service":
       return result(request.id, serviceDetail(loaded, request.serviceId));

--- a/apps/website/src/explorer/worker/protocol.ts
+++ b/apps/website/src/explorer/worker/protocol.ts
@@ -26,6 +26,7 @@ export type Request =
   | {type: "stop", slot: Slot, id: number, stopId: string}
   | {type: "trip", slot: Slot, id: number, tripId: string}
   | {type: "route", slot: Slot, id: number, routeId: string}
+  | {type: "shape", slot: Slot, id: number, shapeId: string}
   | {type: "service", slot: Slot, id: number, serviceId: string}
   | {type: "board", slot: Slot, id: number, stopId: string, date: number}
   | {type: "checks", slot: Slot, id: number, only?: string}

--- a/apps/website/src/styles/explorer.css
+++ b/apps/website/src/styles/explorer.css
@@ -533,6 +533,9 @@ body.is-app main {
   paint-order: stroke;
   vector-effect: non-scaling-stroke;
 }
+/* A route's lines overlap almost everywhere they run, so they are drawn thinner and let each other
+   through - the width of the bundle is then what says how much of the route uses that track. */
+.map__line polyline.map__many { stroke-width: 2.5; stroke-opacity: 0.55; }
 .map__end { fill: var(--on-dark); stroke: var(--signal); stroke-width: 3; }
 .map__end--end { fill: var(--signal); }
 

--- a/apps/website/test/explorer.browser.mts
+++ b/apps/website/test/explorer.browser.mts
@@ -40,6 +40,26 @@ function check(what: string, ok: boolean, detail = ""): void {
   }
 }
 
+/**
+ * Go somewhere and wait for it to actually be on screen.
+ *
+ * Changing only the hash does not reload the page, so every "wait for an element" is satisfied
+ * instantly by the view that is still up - and the checks below it then run against the previous
+ * page and pass. That cost three separate rounds of false green here: a trip asserted against
+ * trips.txt, and a shape and a route asserted against the trip. Waiting for the heading to *change*
+ * is the one condition that does not depend on knowing what the next view contains.
+ */
+async function show(url: string): Promise<void> {
+  const before = (await page.locator("[data-heading]").textContent()) ?? "";
+
+  await page.goto(url);
+  await page.waitForFunction(
+    previous => (document.querySelector("[data-heading]")?.textContent ?? "") !== previous,
+    before,
+    {timeout: 60000}
+  );
+}
+
 /** The site, served under its base path, because every link the build wrote carries one. */
 const server = http.createServer((request, response) => {
   const asked = decodeURIComponent((request.url ?? "/").split("?")[0]);
@@ -244,8 +264,7 @@ const tripId = await page.evaluate(() => {
 
 check("a trip id can be read out of the table", tripId !== null && tripId !== "", tripId ?? "none");
 
-await page.goto(`${at}#/trip/${tripId}`);
-await page.waitForSelector("[data-heading]", {timeout: 60000});
+await show(`${at}#/trip/${tripId}`);
 // Not the count of headings: the "no such trip" view renders one of those too, which is how the
 // wrong id passed this check for a whole run.
 check("a trip opens",
@@ -279,6 +298,11 @@ const drawn = await page.evaluate(() => {
   };
 });
 
+// The rail is where a reader goes looking for a file, and shapes.txt only appears in it if the feed
+// has one - which is why it was missing from the published site until the nightly caught up.
+check("the rail lists the shapes",
+  await page.locator("#explorer-rail a", {hasText: "shapes"}).count() === 1);
+
 check("the line has the points the shape has", (drawn?.count ?? 0) > 1, `${drawn?.count} points`);
 // The whole of it, not the middle of it. This is the zoom being right.
 check("every point of it is inside the box", drawn !== null && drawn.inside === drawn.count,
@@ -286,6 +310,42 @@ check("every point of it is inside the box", drawn !== null && drawn.inside === 
 check("its ends are marked", drawn?.ends === 2, `${drawn?.ends} ends`);
 check("it is drawn in something other than black",
   drawn !== null && drawn.stroke !== "" && drawn.stroke !== "rgb(0, 0, 0)", drawn?.stroke);
+
+// A shape is reachable from the trip's rows link, and from there says what else runs over it.
+const shapeId = await page.evaluate(() =>
+  document.querySelector<HTMLAnchorElement>("a[href*='shape_id=']")?.href.split("shape_id=")[1] ?? null);
+
+check("a trip names the shape it runs over", shapeId !== null, shapeId ?? "none");
+
+await show(`${at}#/shape/${shapeId}`);
+await page.waitForSelector(".map__line polyline", {timeout: 60000});
+check("a shape opens on its own",
+  (await page.locator("[data-heading]").textContent())?.trim() === shapeId, shapeId ?? "");
+check("it says what runs over it",
+  await page.getByRole("heading", {name: "What runs over it"}).count() === 1);
+check("it lists at least one trip", await page.locator(".links li").count() > 0);
+
+// A route draws every distinct line its trips use, which for most routes is more than one.
+const routeId = await page.evaluate(() =>
+  document.querySelector<HTMLAnchorElement>(".links a[href*='#/route/']")?.href.split("#/route/")[1] ?? null);
+
+if (routeId !== null) {
+  await show(`${at}#/route/${routeId}`);
+  await page.waitForSelector(".map__line polyline", {timeout: 60000});
+  check("a route draws where it goes",
+    await page.getByRole("heading", {name: "Where it goes"}).count() === 1, routeId);
+
+  const routeLines = await page.evaluate(() => ({
+    lines: document.querySelectorAll(".map__line polyline").length,
+    said: document.querySelector(".plot__there")?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+  }));
+
+  check("it draws the route's lines", routeLines.lines > 0, `${routeLines.lines} lines`);
+  check("and says how many there are", /line/.test(routeLines.said), routeLines.said.slice(0, 80));
+  // Confetti otherwise: a dozen start and end dots over overlapping lines say nothing.
+  check("it marks no ends when there is more than one line",
+    routeLines.lines === 1 || await page.locator(".map__end").count() === 0);
+}
 
 await page.goto(`${at}#/checks`);
 await page.waitForFunction(


### PR DESCRIPTION
Follow-on from #196. A shape was a column on a trip; it is now something you can navigate to, and a route draws where it goes.

## A shape gets a view

`#/shape/<id>` draws the line, measures it, and lists what runs over it. A shape earns a view of its own because it is **shared** — a trip has one line, but a line has many trips, and "what else runs here" is a question only this end can answer.

`shape_id` joins the columns that are links wherever a table shows one, so `shapes.txt` is somewhere you can navigate from rather than rows of coordinates.

## A route draws where it goes

A route is not one line. A stopping pattern that diverts, a portion that splits and a weekend variation are the same route over different ground, and the picture is the only place that shows. The Tyne & Wear Metro's Green line is **six distinct lines**.

- Drawn thinner and translucent, so the width of the bundle says how much of the route uses that track.
- The busiest twelve are drawn; the count of the rest is written underneath. Past a dozen the map stops saying "the route goes here" and starts saying nothing.
- Ends are marked only when there is one line — a dozen start and end dots over overlapping lines is confetti, and none of them says which line it belongs to.

## On the rail

`shapes.txt` was already there. It only appears if the feed has one, which is why it was missing from the published site until the nightly caught up — the site serves its own mirrored copy of the feed, and that copy predated the shapes.

## Two bugs worth reading

**`parseLines`.** The payload a view hands the map now goes through a parser that refuses anything that is not a list of lines. A single line passed the way one used to be is a flat list of pairs, and *by shape alone that is a list of two-point lines* — so it drew a scatter of stubs and said nothing. That is exactly what the trip view did for one run here when I generalised the map to several lines and missed one call site.

**The browser test was passing against the wrong page.** Three checks. Changing only the hash does not reload, so every "wait for an element" was satisfied instantly by the view still on screen: a trip asserted against `trips.txt`, and a shape and a route asserted against the trip. Navigation now goes through a helper that waits for the heading to *change*, which is the one condition that does not depend on knowing what the next view contains.

One of those three was a fix I made during #196 and then reverted by restoring the file from a stale copy before the last commit — so it merged in the broken state. That is why `.map__line polyline` timed out on the first run here against a feed that definitely has shapes.

## Verified

`node apps/website/test/explorer.browser.mts` against the published `feed-2026-09-10`, which carries 13,054 shapes:

```
ok  the rail lists the shapes
ok  the trip draws the line it runs over
ok  every point of it is inside the box — 10 of 10 inside
ok  a shape opens on its own — f216739b003f
ok  it says what runs over it
ok  a route draws where it goes — GRN
ok  it draws the route's lines — 6 lines
ok  and says how many there are — 6 distinct lines carry this route, all drawn.
ok  it marks no ends when there is more than one line
all checks passed
```

1,352 unit tests pass. No changeset: `@gb-transit/website` is private and publishes nothing.
