### PR TITLE
Send a shape id to the shape view

### DIFF
--- a/apps/website/src/explorer/ui/views/FileTable.spec.ts
+++ b/apps/website/src/explorer/ui/views/FileTable.spec.ts
@@ -1,0 +1,52 @@
+import {describe, it, expect} from "vitest";
+import {LINKS} from "./FileTable.js";
+import {parse, format} from "../../route.js";
+
+/**
+ * Which view each id column opens.
+ *
+ * Worth a test of its own because getting it wrong is invisible: a link that goes to the wrong view
+ * is still a link, and the view at the other end describes whatever it was handed. `shape_id` went
+ * to the service view for a day and reported every shape as a service that runs on no days and has
+ * no trips, which reads like a data problem rather than a broken link.
+ */
+describe("the id columns a table links", () => {
+
+  it("sends each column to the view that explains it", () => {
+    expect(LINKS).to.deep.equal({
+      stop_id: "stop",
+      parent_station: "stop",
+      from_stop_id: "stop",
+      to_stop_id: "stop",
+      trip_id: "trip",
+      from_trip_id: "trip",
+      to_trip_id: "trip",
+      route_id: "route",
+      service_id: "service",
+      shape_id: "shape"
+    });
+  });
+
+  it("sends a shape to the shape view, not the service view", () => {
+    expect(LINKS.shape_id).to.equal("shape");
+  });
+
+  /**
+   * The link has to survive the round trip, or it opens the overview and looks like the id was not
+   * found.
+   */
+  it("builds a link every column parses back to", () => {
+    for (const [column, view] of Object.entries(LINKS)) {
+      const href = format({view, id: "X1"} as never);
+
+      expect(parse(href), column).to.deep.equal({view, id: "X1"});
+    }
+  });
+
+  it("does not link a column that is not an id of something", () => {
+    for (const column of ["shape_pt_lat", "arrival_time", "stop_name", "shape_pt_sequence"]) {
+      expect(LINKS[column], column).to.equal(undefined);
+    }
+  });
+
+});

--- a/apps/website/src/explorer/ui/views/FileTable.ts
+++ b/apps/website/src/explorer/ui/views/FileTable.ts
@@ -21,8 +21,6 @@ export const PAGE_SIZE = 200;
  */
 export function fileTable(page: Page, route: Extract<Route, {view: "file"}>): string {
   const columns = [...page.header];
-  const linkable = new Set(["stop_id", "parent_station", "from_stop_id", "to_stop_id",
-    "trip_id", "from_trip_id", "to_trip_id", "route_id", "service_id", "shape_id"]);
 
   const head = columns.map(column => {
     const descending = route.sort === column && !route.descending;
@@ -41,7 +39,7 @@ export function fileTable(page: Page, route: Extract<Route, {view: "file"}>): st
   const body = page.rows.map(({index, values}) => `<tr>
       <td class="grid__row"><a href="${format(route)}#row-${csvRowNumberOf(index)}"
         title="row ${csvRowNumberOf(index)} of the file">${csvRowNumberOf(index)}</a></td>
-      ${columns.map(column => `<td>${link(column, values[column], linkable)}</td>`).join("")}
+      ${columns.map(column => `<td>${link(column, values[column])}</td>`).join("")}
     </tr>`).join("");
 
   const pages = Math.max(1, Math.ceil(page.matched / PAGE_SIZE));
@@ -101,22 +99,44 @@ function pager(route: Extract<Route, {view: "file"}>, page: Page, pages: number)
 }
 
 /**
+ * A view an identifier alone is enough to open. Not the board, which also needs a date.
+ */
+type IdView = Exclude<Extract<Route, {id: string}>, {view: "board"}>["view"];
+
+/**
+ * The view each identifier column leads to.
+ *
+ * A map rather than a chain of tests ending in a default. The chain ended `: "service"`, so a column
+ * added to it that nobody wrote a branch for did not fail - it linked to the service view and said
+ * a shape id was a service nothing runs on. One list means a column is either in it and right, or
+ * not in it and not a link.
+ */
+export const LINKS: Record<string, IdView> = {
+  stop_id: "stop",
+  parent_station: "stop",
+  from_stop_id: "stop",
+  to_stop_id: "stop",
+  trip_id: "trip",
+  from_trip_id: "trip",
+  to_trip_id: "trip",
+  route_id: "route",
+  service_id: "service",
+  shape_id: "shape"
+};
+
+/**
  * An identifier as a link to the thing it names.
  *
  * This is most of what makes the table an explorer rather than a spreadsheet: every id is a way into
  * the view that explains it, and following a validator's notice to a row and then to the trip it is
  * about takes two clicks.
  */
-function link(column: string, value: string | undefined, linkable: Set<string>): string {
-  if (value === undefined || value === "" || !linkable.has(column)) {
+function link(column: string, value: string | undefined): string {
+  const view = LINKS[column];
+
+  if (value === undefined || value === "" || view === undefined) {
     return cell(value);
   }
 
-  const view = column.includes("trip")
-    ? "trip"
-    : column.includes("stop") || column === "parent_station"
-      ? "stop"
-      : column === "route_id" ? "route" : "service";
-
-  return `<a href="${format({view, id: value} as Route)}">${escape(value)}</a>`;
+  return `<a href="${format({view, id: value})}">${escape(value)}</a>`;
 }

--- a/apps/website/test/explorer.browser.mts
+++ b/apps/website/test/explorer.browser.mts
@@ -311,7 +311,32 @@ check("its ends are marked", drawn?.ends === 2, `${drawn?.ends} ends`);
 check("it is drawn in something other than black",
   drawn !== null && drawn.stroke !== "" && drawn.stroke !== "rgb(0, 0, 0)", drawn?.stroke);
 
+// Following a shape_id out of the table, which is how a reader meets one. It went to the service
+// view for a day and reported every shape as a service that runs on no days - a broken link reads
+// as a data problem, so it is worth clicking rather than only constructing.
+await page.goto(`${at}#/file/trips.txt`);
+await page.waitForSelector(".table__scroll td", {timeout: 60000});
+
+const shapeLink = await page.evaluate(() => {
+  const headers = [...document.querySelectorAll(".table__scroll thead th")]
+    .map(cell => cell.textContent?.trim());
+  const column = headers.indexOf("shape_id");
+  const first = document.querySelector(".table__scroll tbody tr");
+  const anchor = column < 0 || first === null
+    ? null
+    : first.querySelectorAll("td")[column]?.querySelector("a");
+
+  return anchor === null || anchor === undefined
+    ? null
+    : {href: anchor.getAttribute("href"), text: anchor.textContent?.trim() ?? ""};
+});
+
+check("a shape_id in the table is a link", shapeLink !== null, shapeLink?.href ?? "none");
+check("and it points at the shape view, not the service view",
+  shapeLink?.href === `#/shape/${shapeLink?.text}`, shapeLink?.href ?? "none");
+
 // A shape is reachable from the trip's rows link, and from there says what else runs over it.
+await show(`${at}#/trip/${tripId}`);
 const shapeId = await page.evaluate(() =>
   document.querySelector<HTMLAnchorElement>("a[href*='shape_id=']")?.href.split("shape_id=")[1] ?? null);
 


### PR DESCRIPTION
A bug I shipped in #201, reported from the live site.

## What happened

Adding `shape_id` to the set of columns a table links didn't give it a view to link *to*. The chain that picked one ended in a bare default:

```ts
const view = column.includes("trip") ? "trip"
  : column.includes("stop") || column === "parent_station" ? "stop"
    : column === "route_id" ? "route" : "service";
```

`shape_id` matches none of the tests, so it fell through to `"service"`. Every shape id in every table pointed at `#/service/<shape id>`, and the service view then faithfully described a service that isn't there:

> **Service 0004d57185b1** — Described only by its exceptions — calendar.txt has no row for it. · 0 trips · runs on 0 days
> **The days it runs**: *(the entire feed window, every day marked "does not run")*
> **Trips on this service**: Nothing.

Which reads as a data problem rather than a broken link. That's the expensive way to be wrong — it sends you looking at the feed.

## The fix

The chain becomes a map. A column is either in it with a view, or not in it and not a link; there's no default to fall through to.

Its type is `Exclude<Extract<Route, {id: string}>, {view: "board"}>["view"]` — the views an id *alone* can open. The board needs a date, so it can't be a link target, and the `as Route` cast that used to paper over that is gone.

## Tests

None of these existed, which is why this shipped:

- the map asserted whole, so an entry that changes has to be meant;
- every entry checked to build a link that `parse` reads back as the view it came from — a link that doesn't round-trip opens the overview and looks like the id wasn't found;
- the browser follows a `shape_id` out of `trips.txt` and checks **where it lands**, not just that it is a link.

Reverting `shape_id: "shape"` to `"service"` fails two of them.

Verified against the published `feed-2026-09-10`:

```
ok  a shape_id in the table is a link — #/shape/f216739b003f
ok  and it points at the shape view, not the service view — #/shape/f216739b003f
all checks passed
```

1,356 unit tests pass. No changeset: `@gb-transit/website` is private.
